### PR TITLE
Fix datetime json serialization for blob storage

### DIFF
--- a/blob_cache.py
+++ b/blob_cache.py
@@ -9,6 +9,13 @@ import requests
 BLOB_UPLOAD_BASE_URL = "https://blob.vercel-storage.com"
 VERCEL_BLOB_API_URL = "https://api.vercel.com/v2/blobs"
 
+def _json_default(obj: Any):
+    """Best-effort JSON serializer for cache payloads."""
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    # Fallback to string for any other non-serializable objects
+    return str(obj)
+
 
 def _get_token() -> Optional[str]:
     return os.environ.get("BLOB_READ_WRITE_TOKEN")
@@ -95,7 +102,7 @@ def put_cached_json(newsletter_type: str, date_value: datetime, payload: Dict[st
         return None
 
     key = build_blob_key(newsletter_type, date_value)
-    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    body = json.dumps(payload, ensure_ascii=False, default=_json_default).encode("utf-8")
 
     headers = {
         "Authorization": f"Bearer {token}",

--- a/serve.py
+++ b/serve.py
@@ -63,6 +63,8 @@ def get_date_range(start_date, end_date):
 
 def format_date_for_url(date):
     """Format date as YYYY-MM-DD for TLDR URL"""
+    if isinstance(date, str):
+        return date
     return date.strftime('%Y-%m-%d')
 
 def is_sponsored_section(text):


### PR DESCRIPTION
Add a custom JSON serializer for `datetime` objects and make `format_date_for_url` tolerant of string inputs.

This fixes the `Object of type datetime is not JSON serializable` error that occurred when caching payloads containing `datetime` objects to blob storage.

---
<a href="https://cursor.com/background-agent?bcId=bc-639b222f-b728-44ce-a8f3-1e79ddd2cf0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-639b222f-b728-44ce-a8f3-1e79ddd2cf0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

