### PR TITLE
Import Vollkorn serif font

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,9 @@
     <meta name="color-scheme" content="light dark">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.0/github-markdown-light.min.css" media="(prefers-color-scheme: light)">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.0/github-markdown-dark.min.css" media="(prefers-color-scheme: dark)">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Vollkorn:ital,wght@0,400..900;1,400..900&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg: #f6f7f9;
@@ -145,7 +148,7 @@
             margin: 0 auto;
             padding: 16px 16px 24px;
             color: var(--text);
-            font-family: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+            font-family: 'Vollkorn', ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
             font-size: 17px;
             line-height: 1.75;
             text-wrap: pretty;


### PR DESCRIPTION
Add Vollkorn font import and apply it to the serif font stack for `.markdown-body`.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f8c181e-d966-4fce-85c4-fe48ddb881fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f8c181e-d966-4fce-85c4-fe48ddb881fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

