### PR TITLE
Fix text justification in css and html

### DIFF
--- a/static/whitey.css
+++ b/static/whitey.css
@@ -34,7 +34,7 @@
   color: var(--whitey-text);
   font-family: "Vollkorn", Palatino, Times;
   line-height: 1.53;      /* matches Typora Whitey’s reading rhythm */
-  text-align: justify;
+  text-align: left;
   background: transparent;
 }
 


### PR DESCRIPTION
Change `#write` text alignment from `justify` to `left`.

The previous `text-align: justify;` rule was causing text to be justified to both sides, and the user requested it be regular left-justified.

---
<a href="https://cursor.com/background-agent?bcId=bc-665e9ba0-bf09-4372-a70f-e4106aef174f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-665e9ba0-bf09-4372-a70f-e4106aef174f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

