### PR TITLE
Extract and display domain name from URL

### DIFF
--- a/newsletter_scraper.py
+++ b/newsletter_scraper.py
@@ -156,16 +156,9 @@ def _format_final_output(start_date, end_date, grouped_articles):
             output += f"#### {category}\n\n"
 
             for i, article in enumerate(category_articles, 1):
-                status = article.get("fetched_via", "unknown")
-                if status not in ("day_cache", "network"):
-                    status = "unknown"
-                total_ms = article.get("timing_total_ms")
-                if total_ms is not None:
-                    timing_label = f", {total_ms}ms"
-                else:
-                    timing_label = ""
-                title_with_status = f"{article['title']} ({status}{timing_label})"
-                output += f"{i}. [{title_with_status}]({article['url']})\n"
+                domain_name = util.get_domain_name(article['url'])
+                title_with_domain = f"{article['title']} ({domain_name})"
+                output += f"{i}. [{title_with_domain}]({article['url']})\n"
 
             output += "\n"
 

--- a/util.py
+++ b/util.py
@@ -48,3 +48,83 @@ def canonicalize_url(url) -> str:
     if canonical.endswith("/") and len(canonical) > 1:
         canonical = canonical[:-1]
     return canonical
+
+
+def get_domain_name(url) -> str:
+    """Extract a friendly domain name from a URL"""
+    import urllib.parse as urlparse
+    
+    try:
+        parsed = urlparse.urlparse(url)
+        hostname = parsed.netloc.lower()
+        
+        # Remove www. prefix if present
+        if hostname.startswith('www.'):
+            hostname = hostname[4:]
+        
+        # Remove port number if present
+        hostname = hostname.split(':')[0]
+        
+        # Map common domains to friendly names
+        domain_map = {
+            'google.com': 'Google',
+            'youtube.com': 'YouTube',
+            'github.com': 'GitHub',
+            'stackoverflow.com': 'Stack Overflow',
+            'reddit.com': 'Reddit',
+            'twitter.com': 'Twitter',
+            'x.com': 'X',
+            'facebook.com': 'Facebook',
+            'linkedin.com': 'LinkedIn',
+            'medium.com': 'Medium',
+            'techcrunch.com': 'TechCrunch',
+            'theverge.com': 'The Verge',
+            'arstechnica.com': 'Ars Technica',
+            'wired.com': 'Wired',
+            'engadget.com': 'Engadget',
+            'reuters.com': 'Reuters',
+            'bloomberg.com': 'Bloomberg',
+            'nytimes.com': 'New York Times',
+            'washingtonpost.com': 'Washington Post',
+            'bbc.com': 'BBC',
+            'bbc.co.uk': 'BBC',
+            'cnn.com': 'CNN',
+            'theguardian.com': 'The Guardian',
+            'forbes.com': 'Forbes',
+            'wsj.com': 'Wall Street Journal',
+            'arxiv.org': 'arXiv',
+            'nature.com': 'Nature',
+            'science.org': 'Science',
+            'openai.com': 'OpenAI',
+            'anthropic.com': 'Anthropic',
+            'deepmind.com': 'DeepMind',
+            'microsoft.com': 'Microsoft',
+            'apple.com': 'Apple',
+            'amazon.com': 'Amazon',
+            'netflix.com': 'Netflix',
+            'spotify.com': 'Spotify',
+            'slack.com': 'Slack',
+            'discord.com': 'Discord',
+            'notion.so': 'Notion',
+            'figma.com': 'Figma',
+            'vercel.com': 'Vercel',
+            'netlify.com': 'Netlify',
+        }
+        
+        if hostname in domain_map:
+            return domain_map[hostname]
+        
+        # For unmapped domains, capitalize the main part
+        # e.g., "example.com" -> "Example"
+        parts = hostname.split('.')
+        if len(parts) >= 2:
+            # Use the second-to-last part (main domain name)
+            main_part = parts[-2]
+            return main_part.capitalize()
+        elif len(parts) == 1:
+            return parts[0].capitalize()
+        
+        return hostname.capitalize()
+    
+    except Exception:
+        return "Unknown"


### PR DESCRIPTION
Display the domain name of an article's URL instead of its fetch status and timing to provide a cleaner, more user-friendly output.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbcca75d-1963-40a1-afe1-86fb8646e413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fbcca75d-1963-40a1-afe1-86fb8646e413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

