### PR TITLE
Rename summary effort terminology to reasoning effort

### DIFF
--- a/blob_cache.py
+++ b/blob_cache.py
@@ -29,9 +29,9 @@ def blob_cached(
         def wrapper(path: str, *args: P.args, **kwargs: P.kwargs) -> R:
             # Extract cache_only from kwargs (don't pass it to the underlying function)
             cache_only = kwargs.pop('cache_only', False)
-            
+
             # First arg is the URL/string for pathname generation
-            pathname = pathname_fn(path)
+            pathname = pathname_fn(path, *args, **kwargs)
             blob_base_url = util.resolve_env_var("BLOB_STORE_BASE_URL", "").strip()
 
             # Early return: Check if cache reads are allowed

--- a/templates/index.html
+++ b/templates/index.html
@@ -283,6 +283,23 @@
             opacity: 1;
         }
 
+        .reasoning-effort-select {
+            display: none;
+            height: 32px;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            background: #fff;
+            color: var(--text);
+            font-size: 12px;
+            padding: 0 8px;
+            cursor: pointer;
+        }
+
+        .reasoning-effort-select.visible {
+            display: inline-flex;
+            align-items: center;
+        }
+
         .article-btn {
             width: 32px;
             height: 32px;
@@ -595,6 +612,104 @@
             copyBtn.classList.remove('visible');
         }
 
+        const REASONING_EFFORT_OPTIONS = [
+            { value: 'minimal', label: 'Minimal reasoning effort' },
+            { value: 'low', label: 'Low reasoning effort' },
+            { value: 'medium', label: 'Medium reasoning effort' },
+            { value: 'high', label: 'High reasoning effort' }
+        ];
+
+        function normalizeReasoningEffort(value) {
+            if (typeof value !== 'string') return 'low';
+            const normalized = value.trim().toLowerCase();
+            return REASONING_EFFORT_OPTIONS.some((opt) => opt.value === normalized) ? normalized : 'low';
+        }
+
+        function getCardReasoningEffort(card) {
+            if (!card) return 'low';
+            return normalizeReasoningEffort(card.getAttribute('data-reasoning-effort') || 'low');
+        }
+
+        function setCardReasoningEffort(card, value) {
+            if (!card) return;
+            const previousEffort = normalizeReasoningEffort(card.getAttribute('data-reasoning-effort') || 'low');
+            const effort = normalizeReasoningEffort(value);
+            if (previousEffort !== effort) {
+                card.removeAttribute('data-summary');
+                const existingSummary = card.querySelector('.inline-summary');
+                if (existingSummary) {
+                    existingSummary.remove();
+                }
+                const expandBtnReset = card.querySelector('.expand-btn');
+                if (expandBtnReset) {
+                    expandBtnReset.classList.remove('expanded');
+                    expandBtnReset.innerHTML = '↓';
+                    expandBtnReset.title = 'Show summary';
+                }
+                toggleCopyButton(card, false);
+            }
+            card.setAttribute('data-reasoning-effort', effort);
+            const expandBtn = card.querySelector('.expand-btn');
+            if (expandBtn) {
+                expandBtn.dataset.reasoningEffort = effort;
+            }
+        }
+
+        function setupReasoningEffortControls(card, expandBtn, effortSelect) {
+            if (!card || !expandBtn || !effortSelect) return;
+
+            const LONG_PRESS_DURATION = 600;
+            let longPressTimer = null;
+
+            function hideSelect() {
+                effortSelect.classList.remove('visible');
+                effortSelect.style.display = 'none';
+                delete expandBtn.dataset.skipNextClick;
+            }
+
+            function showSelect() {
+                effortSelect.value = getCardReasoningEffort(card);
+                effortSelect.classList.add('visible');
+                effortSelect.style.display = 'inline-flex';
+                expandBtn.dataset.skipNextClick = 'true';
+                requestAnimationFrame(() => {
+                    effortSelect.focus();
+                });
+            }
+
+            function startPress(event) {
+                if (expandBtn.disabled) return;
+                if (event.type === 'mousedown' && event.button !== 0) return;
+                clearTimeout(longPressTimer);
+                longPressTimer = setTimeout(() => {
+                    showSelect();
+                }, LONG_PRESS_DURATION);
+            }
+
+            function cancelPress() {
+                clearTimeout(longPressTimer);
+            }
+
+            expandBtn.addEventListener('mousedown', startPress);
+            expandBtn.addEventListener('touchstart', startPress);
+            expandBtn.addEventListener('mouseup', cancelPress);
+            expandBtn.addEventListener('mouseleave', cancelPress);
+            expandBtn.addEventListener('touchend', cancelPress);
+            expandBtn.addEventListener('touchcancel', cancelPress);
+            expandBtn.addEventListener('touchmove', cancelPress);
+
+            effortSelect.addEventListener('change', (event) => {
+                setCardReasoningEffort(card, event.target.value || 'low');
+                hideSelect();
+            });
+
+            effortSelect.addEventListener('blur', () => {
+                hideSelect();
+            });
+
+            hideSelect();
+        }
+
         // Form submission handler - use backend API
         document.getElementById('scrapeForm').addEventListener('submit', async function(e) {
             e.preventDefault();
@@ -763,6 +878,16 @@
                             expandBtn.setAttribute('data-url', urlValue);
                             expandBtn.type = 'button';
 
+                            const effortSelect = document.createElement('select');
+                            effortSelect.className = 'reasoning-effort-select';
+                            effortSelect.setAttribute('aria-label', 'Reasoning effort level');
+                            REASONING_EFFORT_OPTIONS.forEach((option) => {
+                                const opt = document.createElement('option');
+                                opt.value = option.value;
+                                opt.textContent = option.label;
+                                effortSelect.appendChild(opt);
+                            });
+
                             const copyBtn = document.createElement('button');
                             copyBtn.className = 'article-btn copy-summary-btn';
                             copyBtn.innerHTML = clipboardIconMarkup;
@@ -785,10 +910,15 @@
                             header.appendChild(content);
                             header.appendChild(actions);
                             actions.appendChild(expandBtn);
+                            actions.appendChild(effortSelect);
                             actions.appendChild(copyBtn);
                             actions.appendChild(removeBtn);
                             card.appendChild(header);
-                            
+
+                            setCardReasoningEffort(card, 'low');
+                            effortSelect.value = getCardReasoningEffort(card);
+                            setupReasoningEffortControls(card, expandBtn, effortSelect);
+
                             articleList.appendChild(card);
                         });
                         
@@ -837,22 +967,26 @@
                 setTimeout(async () => {
                     const url = btn.getAttribute('data-url');
                     if (!url) return;
-                    
+                    const card = btn.closest('.article-card');
+                    const reasoningEffort = getCardReasoningEffort(card);
+
                     try {
                         const resp = await fetch('/api/summarize-url', {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ url: url, cache_only: true })
+                            body: JSON.stringify({ url: url, cache_only: true, reasoning_effort: reasoningEffort })
                         });
                         const data = await resp.json();
-                        
+
                         if (data.success) {
+                            if (card && getCardReasoningEffort(card) !== reasoningEffort) {
+                                return;
+                            }
                             // Mark button as having loaded summary
                             btn.classList.add('loaded');
                             btn.title = 'Show summary';
-                            
+
                             // Store the summary data
-                            const card = btn.closest('.article-card');
                             if (card) {
                                 card.setAttribute('data-summary', data.summary_markdown || '');
                             }
@@ -1065,7 +1199,12 @@
             // Check if it's an expand button
             const expandBtn = e.target.closest('.expand-btn');
             const link = e.target.closest('.article-link');
-            
+
+            if (expandBtn && expandBtn.dataset.skipNextClick === 'true') {
+                delete expandBtn.dataset.skipNextClick;
+                return;
+            }
+
             if (!expandBtn && !link) return;
             
             const target = expandBtn || link;
@@ -1088,6 +1227,7 @@
             e.stopPropagation();
             
             const btn = card.querySelector('.expand-btn');
+            const reasoningEffort = getCardReasoningEffort(card);
             
             // Check if summary already exists
             let expander = card.querySelector('.inline-summary');
@@ -1156,10 +1296,22 @@
                 const resp = await fetch('/api/summarize-url', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ url: url })
+                    body: JSON.stringify({ url: url, reasoning_effort: reasoningEffort })
                 });
                 const data = await resp.json();
                 if (data.success) {
+                    if (getCardReasoningEffort(card) !== reasoningEffort) {
+                        if (btn) {
+                            btn.disabled = false;
+                            btn.innerHTML = '↓';
+                            btn.title = 'Show summary';
+                        }
+                        if (expander && expander.parentNode) {
+                            expander.remove();
+                        }
+                        toggleCopyButton(card, false);
+                        return;
+                    }
                     const html = DOMPurify.sanitize(marked.parse(data.summary_markdown || ''));
                     expander.innerHTML = '<strong>Summary</strong>' + html;
                     // Make links inside the inline summary safe/tabbed and don't trigger expansion


### PR DESCRIPTION
## Summary
- rename the summary effort selector UI and options to reasoning effort and update request payloads
- update the Flask endpoint and summarizer helpers to use reasoning effort terminology and accept the new parameter
- keep dropdown styling consistent with the new reasoning effort class names

## Testing
- uv run python3 -m compileall summarizer.py serve.py

------
https://chatgpt.com/codex/tasks/task_e_68ded885c7f88332963baa496569c333