### PR TITLE
Remove summary cache debug appendix

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -141,16 +141,9 @@ def summarize_url_endpoint():
             else None
         )
 
-        debug_appendix = (
-            f"\n\n---\n"
-            f"Debug: Summary cache key candidate\n"
-            f"- candidate: `{summary_blob_pathname_value}`\n"
-            f"- effort: `{summary_effort}`\n"
-        )
-
         return jsonify({
             "success": True,
-            "summary_markdown": summary + debug_appendix,
+            "summary_markdown": summary,
             "summary_blob_url": summary_blob_url,
             "summary_blob_pathname": summary_blob_pathname_value,
         })


### PR DESCRIPTION
## Summary
- remove the debug-only summary cache key appendix from the summarize-url response
- keep returning existing summary metadata without the debug block so the frontend continues to function

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e01c1eb4ec83329868ec0c825a5ace