### PR TITLE
Avoid following redirects when fetching newsletters

### DIFF
--- a/newsletter_scraper.py
+++ b/newsletter_scraper.py
@@ -264,6 +264,7 @@ def _fetch_newsletter(date, newsletter_type):
             url,
             timeout=30,
             headers={"User-Agent": "Mozilla/5.0 (compatible; TLDR-Scraper/1.0)"},
+            allow_redirects=False,
         )
         net_ms = int(round((time.time() - net_start) * 1000))
 
@@ -271,6 +272,9 @@ def _fetch_newsletter(date, newsletter_type):
             return None
 
         response.raise_for_status()
+
+        if response.is_redirect:
+            return None
 
         convert_start = time.time()
         markdown_content = _extract_newsletter_content(response.text)


### PR DESCRIPTION
## Summary
- disable redirects on newsletter fetch requests
- treat redirect responses as missing newsletters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e129300cb48332892210759245c501