### PR TITLE
Find missing url canonicalization step

### DIFF
--- a/newsletter_scraper.py
+++ b/newsletter_scraper.py
@@ -347,6 +347,7 @@ def scrape_date_range(start_date, end_date):
 
             for article in cached_articles:
                 canonical_url = util.canonicalize_url(article["url"])
+                article["url"] = canonical_url
 
                 if canonical_url not in url_set:
                     url_set.add(canonical_url)
@@ -373,6 +374,7 @@ def scrape_date_range(start_date, end_date):
             if result and result["articles"]:
                 for article in result["articles"]:
                     canonical_url = util.canonicalize_url(article["url"])
+                    article["url"] = canonical_url
 
                     day_articles.append(article)
 


### PR DESCRIPTION
Update `article["url"]` to its canonicalized version to ensure clients receive clean URLs without tracking parameters.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf64db48-d9fb-48b6-b515-5982d0f909ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bf64db48-d9fb-48b6-b515-5982d0f909ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

