### PR TITLE
Extract API logic into service layer and add CLI entrypoint

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+
+from tldr_service import (
+    fetch_prompt_template,
+    remove_url,
+    scrape_newsletters,
+    summarize_url_content,
+)
+
+
+def _print_error(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+def _json_dumps(data: object) -> str:
+    return json.dumps(data, indent=2, sort_keys=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="TLDR Scraper local CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    scrape_parser = subparsers.add_parser("scrape", help="Scrape newsletters")
+    scrape_parser.add_argument(
+        "--start-date", required=True, help="ISO start date (YYYY-MM-DD)"
+    )
+    scrape_parser.add_argument(
+        "--end-date", required=True, help="ISO end date (YYYY-MM-DD)"
+    )
+
+    summarize_parser = subparsers.add_parser(
+        "summarize-url", help="Summarize a URL using the existing summarizer"
+    )
+    summarize_parser.add_argument("--url", required=True, help="URL to summarize")
+    summarize_parser.add_argument(
+        "--summary-effort",
+        default="low",
+        help="Summary effort (low, medium, high)",
+    )
+    summarize_parser.add_argument(
+        "--cache-only",
+        action="store_true",
+        help="Only return cached summaries",
+    )
+
+    subparsers.add_parser("prompt", help="Print the summarize prompt template")
+
+    remove_parser = subparsers.add_parser(
+        "remove-url", help="Mark a URL as removed"
+    )
+    remove_parser.add_argument("--url", required=True, help="URL to remove")
+
+    args = parser.parse_args()
+
+    if args.command == "scrape":
+        try:
+            result = scrape_newsletters(args.start_date, args.end_date)
+            print(_json_dumps(result))
+        except Exception as error:
+            _print_error(str(error))
+            sys.exit(1)
+        return
+
+    if args.command == "prompt":
+        try:
+            print(fetch_prompt_template())
+        except Exception as error:
+            _print_error(str(error))
+            sys.exit(1)
+        return
+
+    if args.command == "summarize-url":
+        try:
+            result = summarize_url_content(
+                args.url,
+                cache_only=args.cache_only,
+                summary_effort=args.summary_effort,
+            )
+            if result is None:
+                _print_error("No cached summary available")
+                sys.exit(1)
+            payload = {
+                "summary_markdown": result["summary_markdown"],
+                "summary_blob_url": result["summary_blob_url"],
+                "summary_blob_pathname": result["summary_blob_pathname"],
+                "canonical_url": result["canonical_url"],
+                "summary_effort": result["summary_effort"],
+            }
+            print(_json_dumps(payload))
+        except Exception as error:
+            _print_error(str(error))
+            sys.exit(1)
+        return
+
+    if args.command == "remove-url":
+        try:
+            canonical_url = remove_url(args.url)
+            print(_json_dumps({"canonical_url": canonical_url}))
+        except Exception as error:
+            _print_error(str(error))
+            sys.exit(1)
+        return
+
+
+if __name__ == "__main__":
+    main()

--- a/tldr_service.py
+++ b/tldr_service.py
@@ -1,0 +1,124 @@
+import logging
+from datetime import datetime
+from typing import Optional
+
+import requests
+
+import util
+from newsletter_scraper import scrape_date_range
+from removed_urls import add_removed_url
+from summarizer import (
+    _fetch_summarize_prompt,
+    normalize_summary_effort,
+    summarize_url,
+    summary_blob_pathname,
+)
+
+logger = logging.getLogger("tldr_service")
+
+
+def _parse_date_range(start_date_text: str, end_date_text: str) -> tuple[datetime, datetime]:
+    """Parse ISO date strings and enforce range limits.
+
+    >>> _parse_date_range("2024-01-01", "2024-01-02")[0].isoformat()
+    '2024-01-01T00:00:00'
+    """
+    if not start_date_text or not end_date_text:
+        raise ValueError("start_date and end_date are required")
+
+    try:
+        start_date = datetime.fromisoformat(start_date_text)
+        end_date = datetime.fromisoformat(end_date_text)
+    except ValueError as error:
+        raise ValueError("Dates must be ISO formatted (YYYY-MM-DD)") from error
+
+    if start_date > end_date:
+        raise ValueError("start_date must be before or equal to end_date")
+
+    if (end_date - start_date).days >= 31:
+        raise ValueError("Date range cannot exceed 31 days")
+
+    return start_date, end_date
+
+
+def scrape_newsletters(start_date_text: str, end_date_text: str) -> dict:
+    start_date, end_date = _parse_date_range(start_date_text, end_date_text)
+    util.log(
+        f"[tldr_service.scrape_newsletters] start start_date={start_date_text} end_date={end_date_text}",
+        logger=logger,
+    )
+    result = scrape_date_range(start_date, end_date)
+    util.log(
+        f"[tldr_service.scrape_newsletters] done dates_processed={result['stats']['dates_processed']} total_articles={result['stats']['total_articles']}",
+        logger=logger,
+    )
+    return result
+
+
+def fetch_prompt_template() -> str:
+    return _fetch_summarize_prompt()
+
+
+def summarize_url_content(
+    url: str,
+    *,
+    cache_only: bool = False,
+    summary_effort: str = "low",
+) -> Optional[dict]:
+    cleaned_url = (url or "").strip()
+    if not cleaned_url:
+        raise ValueError("Missing url")
+
+    canonical_url = util.canonicalize_url(cleaned_url)
+    normalized_effort = normalize_summary_effort(summary_effort)
+
+    try:
+        summary_markdown = summarize_url(
+            canonical_url,
+            summary_effort=normalized_effort,
+            cache_only=cache_only,
+        )
+    except requests.RequestException as error:
+        util.log(
+            "[tldr_service.summarize_url_content] request error error=%s",
+            repr(error),
+            level=logging.ERROR,
+            exc_info=True,
+            logger=logger,
+        )
+        raise
+
+    if summary_markdown is None:
+        return None
+
+    summary_blob_pathname_value = summary_blob_pathname(
+        canonical_url, summary_effort=normalized_effort
+    )
+    blob_base_url = util.resolve_env_var("BLOB_STORE_BASE_URL", "").strip()
+    summary_blob_url = (
+        f"{blob_base_url}/{summary_blob_pathname_value}" if blob_base_url else None
+    )
+
+    return {
+        "summary_markdown": summary_markdown,
+        "summary_blob_pathname": summary_blob_pathname_value,
+        "summary_blob_url": summary_blob_url,
+        "canonical_url": canonical_url,
+        "summary_effort": normalized_effort,
+    }
+
+
+def remove_url(url: str) -> str:
+    cleaned_url = (url or "").strip()
+    if not cleaned_url or not (
+        cleaned_url.startswith("http://") or cleaned_url.startswith("https://")
+    ):
+        raise ValueError("Invalid or missing url")
+
+    canonical_url = util.canonicalize_url(cleaned_url)
+    success = add_removed_url(canonical_url)
+
+    if not success:
+        raise RuntimeError("Failed to persist removal")
+
+    return canonical_url


### PR DESCRIPTION
## Summary
- extract request-agnostic newsletter, summary, and removal logic into `tldr_service`
- update Flask routes to delegate to the shared service helpers
- add a `cli.py` entry point so the operations can run from the command line

## Testing
- uv run python3 -m compileall cli.py tldr_service.py serve.py
- uv run python3 cli.py --help

------
https://chatgpt.com/codex/tasks/task_e_68e5ff74323483328044a9c78348d009