### PR TITLE
Decouple API logic for CLI reuse

### DIFF
--- a/scripts/tldr_cli.py
+++ b/scripts/tldr_cli.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import util
+from tldr_service import (
+    ServiceError,
+    fetch_prompt_template,
+    remove_url as remove_url_from_service,
+    scrape_newsletters as scrape_newsletters_from_service,
+    summarize_url_content,
+)
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(level=util.resolve_env_var("LOG_LEVEL", "INFO"))
+
+
+def _print_json(payload):
+    json.dump(payload, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def _handle_error(error: Exception, logger: logging.Logger) -> None:
+    util.log(
+        f"[tldr_cli] error error={repr(error)}",
+        level=logging.ERROR,
+        logger=logger,
+    )
+    if isinstance(error, ServiceError):
+        message = {"success": False, "error": str(error)}
+    else:
+        message = {"success": False, "error": repr(error)}
+    json.dump(message, sys.stderr, indent=2)
+    sys.stderr.write("\n")
+    sys.stderr.flush()
+
+
+def _scrape(args, logger):
+    result = scrape_newsletters_from_service(args.start_date, args.end_date)
+    _print_json(result)
+
+
+def _prompt(args, logger):
+    prompt = fetch_prompt_template()
+    sys.stdout.write(prompt)
+    if not prompt.endswith("\n"):
+        sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def _summarize(args, logger):
+    result = summarize_url_content(
+        args.url,
+        cache_only=args.cache_only,
+        summary_effort=args.summary_effort,
+    )
+    _print_json(result)
+
+
+def _remove(args, logger):
+    result = remove_url_from_service(args.url)
+    _print_json(result)
+
+
+def main(argv=None):
+    _configure_logging()
+    logger = logging.getLogger("tldr_cli")
+
+    parser = argparse.ArgumentParser(description="CLI for TLDR Scraper operations")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    scrape_parser = subparsers.add_parser(
+        "scrape", help="Scrape newsletters for a date range"
+    )
+    scrape_parser.add_argument("start_date", help="Start date (YYYY-MM-DD)")
+    scrape_parser.add_argument("end_date", help="End date (YYYY-MM-DD)")
+    scrape_parser.set_defaults(func=_scrape)
+
+    prompt_parser = subparsers.add_parser(
+        "prompt", help="Show the summarize prompt template"
+    )
+    prompt_parser.set_defaults(func=_prompt)
+
+    summarize_parser = subparsers.add_parser(
+        "summarize-url", help="Summarize a URL"
+    )
+    summarize_parser.add_argument("url", help="URL to summarize")
+    summarize_parser.add_argument(
+        "--cache-only",
+        action="store_true",
+        help="Only return cached summaries",
+    )
+    summarize_parser.add_argument(
+        "--summary-effort",
+        default="low",
+        help="Summary effort level",
+    )
+    summarize_parser.set_defaults(func=_summarize)
+
+    remove_parser = subparsers.add_parser(
+        "remove-url", help="Remove a URL from future scrapes"
+    )
+    remove_parser.add_argument("url", help="URL to remove")
+    remove_parser.set_defaults(func=_remove)
+
+    args = parser.parse_args(argv)
+
+    try:
+        args.func(args, logger)
+    except Exception as error:  # noqa: BLE001
+        _handle_error(error, logger)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tldr_service.py
+++ b/tldr_service.py
@@ -1,0 +1,173 @@
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import requests
+
+import util
+from newsletter_scraper import scrape_date_range
+from removed_urls import add_removed_url
+from summarizer import (
+    _fetch_summarize_prompt,
+    normalize_summary_effort,
+    summarize_url,
+    summary_blob_pathname,
+)
+
+logger = logging.getLogger("tldr_service")
+
+
+class ServiceError(Exception):
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class ValidationError(ServiceError):
+    pass
+
+
+class ProcessingError(ServiceError):
+    def __init__(self, message: str, status_code: int = 500):
+        super().__init__(message, status_code=status_code)
+
+
+def _parse_iso_date(value: Optional[str], field_name: str) -> datetime:
+    if not value:
+        raise ValidationError(f"{field_name} is required")
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValidationError(
+            f"{field_name} must be an ISO formatted date string"
+        ) from exc
+
+
+def scrape_newsletters(start_date: Optional[str], end_date: Optional[str]) -> Dict[str, Any]:
+    start = _parse_iso_date(start_date, "start_date")
+    end = _parse_iso_date(end_date, "end_date")
+
+    if start > end:
+        raise ValidationError("start_date must be before or equal to end_date")
+
+    if (end - start).days >= 31:
+        raise ValidationError("Date range cannot exceed 31 days")
+
+    util.log(
+        f"[tldr_service.scrape_newsletters] start start_date={start_date} end_date={end_date}",
+        logger=logger,
+    )
+
+    try:
+        result = scrape_date_range(start, end)
+    except Exception as exc:
+        util.log(
+            f"[tldr_service.scrape_newsletters] failed error={repr(exc)}",
+            level=logging.ERROR,
+            logger=logger,
+            exc_info=True,
+        )
+        raise ProcessingError(str(exc)) from exc
+
+    util.log(
+        (
+            "[tldr_service.scrape_newsletters] done dates_processed="
+            f"{result['stats']['dates_processed']} total_articles={result['stats']['total_articles']}"
+        ),
+        logger=logger,
+    )
+    return result
+
+
+def fetch_prompt_template() -> str:
+    try:
+        return _fetch_summarize_prompt()
+    except Exception as exc:
+        util.log(
+            f"[tldr_service.fetch_prompt_template] failed error={repr(exc)}",
+            level=logging.ERROR,
+            logger=logger,
+            exc_info=True,
+        )
+        raise ProcessingError(f"Error loading prompt: {exc!r}") from exc
+
+
+def summarize_url_content(
+    url: Optional[str],
+    *,
+    cache_only: bool = False,
+    summary_effort: str = "low",
+) -> Dict[str, Any]:
+    if not url or not url.strip():
+        raise ValidationError("Missing url")
+
+    canonical_url = util.canonicalize_url(url.strip())
+    normalized_effort = normalize_summary_effort(summary_effort)
+
+    try:
+        summary = summarize_url(
+            canonical_url,
+            summary_effort=normalized_effort,
+            cache_only=cache_only,
+        )
+    except requests.RequestException as exc:
+        util.log(
+            f"[tldr_service.summarize_url_content] network error error={repr(exc)}",
+            level=logging.ERROR,
+            logger=logger,
+            exc_info=True,
+        )
+        raise ProcessingError(f"Network error: {repr(exc)}", status_code=502) from exc
+    except Exception as exc:
+        util.log(
+            f"[tldr_service.summarize_url_content] failed error={repr(exc)}",
+            level=logging.ERROR,
+            logger=logger,
+            exc_info=True,
+        )
+        raise ProcessingError(repr(exc)) from exc
+
+    if summary is None:
+        return {"success": False, "error": "No cached summary available"}
+
+    summary_blob_pathname_value = summary_blob_pathname(
+        canonical_url, summary_effort=normalized_effort
+    )
+    blob_base_url = util.resolve_env_var("BLOB_STORE_BASE_URL", "").strip()
+    summary_blob_url = (
+        f"{blob_base_url}/{summary_blob_pathname_value}" if blob_base_url else None
+    )
+
+    return {
+        "success": True,
+        "summary_markdown": summary,
+        "summary_blob_url": summary_blob_url,
+        "summary_blob_pathname": summary_blob_pathname_value,
+    }
+
+
+def remove_url(url: Optional[str]) -> Dict[str, Any]:
+    if not url or not url.strip():
+        raise ValidationError("Invalid or missing url")
+
+    cleaned = url.strip()
+    if not (cleaned.startswith("http://") or cleaned.startswith("https://")):
+        raise ValidationError("Invalid or missing url")
+
+    canonical = util.canonicalize_url(cleaned)
+
+    try:
+        success = add_removed_url(canonical)
+    except Exception as exc:
+        util.log(
+            f"[tldr_service.remove_url] failed error={repr(exc)}",
+            level=logging.ERROR,
+            logger=logger,
+            exc_info=True,
+        )
+        raise ProcessingError(repr(exc)) from exc
+
+    if not success:
+        raise ProcessingError("Failed to persist removal")
+
+    return {"success": True, "canonical_url": canonical}


### PR DESCRIPTION
## Summary
- extract newsletter scraping, prompt loading, summarization, and removal logic into a reusable `tldr_service` module
- simplify Flask endpoints to delegate to the shared service layer while preserving error handling
- add a `scripts/tldr_cli.py` entrypoint so the same operations can be exercised locally from the command line

## Testing
- uv run python3 scripts/tldr_cli.py --help

------
https://chatgpt.com/codex/tasks/task_e_68e5ff74323483328044a9c78348d009