### PR TITLE
Implement collapsible issue-day read state

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -940,15 +940,16 @@
             width: 100%;
         }
 
-        .collapsed-issue:not(.expanded) .collapsed-issue-header {
-            cursor: pointer;
-        }
-
         .collapsed-issue-title {
             flex: 1;
             font-size: 15px;
             font-weight: 500;
             color: var(--text);
+            cursor: pointer;
+        }
+
+        .collapsed-issue-title:hover {
+            color: var(--link);
         }
 
         .collapsed-issue:not(.expanded) .mark-read-btn {
@@ -2373,7 +2374,7 @@
                 
                 const title = document.createElement('div');
                 title.className = 'collapsed-issue-title';
-                title.textContent = '▶ ' + headerText + ' – ' + date;
+                title.textContent = headerText + ' – ' + date;
                 
                 const markReadBtn = document.createElement('button');
                 markReadBtn.className = 'mark-read-btn';
@@ -2449,17 +2450,7 @@
                 const collapsedIssue = titleEl.closest('.collapsed-issue');
                 if (!collapsedIssue) return;
                 
-                const isExpanded = collapsedIssue.classList.contains('expanded');
-                
-                if (isExpanded) {
-                    collapsedIssue.classList.remove('expanded');
-                    if (!titleEl.textContent.startsWith('▶ ')) {
-                        titleEl.textContent = '▶ ' + titleEl.textContent;
-                    }
-                } else {
-                    collapsedIssue.classList.add('expanded');
-                    titleEl.textContent = titleEl.textContent.replace('▶ ', '');
-                }
+                collapsedIssue.classList.toggle('expanded');
             });
         }
 
@@ -2482,15 +2473,7 @@
                     const collapsedIssue = btn.closest('.collapsed-issue');
                     if (collapsedIssue) {
                         console.log('Collapsing expanded read issue', {show: true});
-                        const issueKey = collapsedIssue.getAttribute('data-issue-key');
-                        if (issueKey) {
-                            setIssueRead(issueKey, true);
-                            collapsedIssue.classList.remove('expanded');
-                            const title = collapsedIssue.querySelector('.collapsed-issue-title');
-                            if (title && !title.textContent.startsWith('▶ ')) {
-                                title.textContent = '▶ ' + title.textContent;
-                            }
-                        }
+                        collapsedIssue.classList.remove('expanded');
                         return;
                     }
                     


### PR DESCRIPTION
Implement a "Mark as Read" feature for issue-days, allowing users to collapse and move read content to the bottom of the page for better mobile UX and content management.

This feature addresses the user's need to manage their reading flow, especially on mobile, by providing a clear way to dismiss consumed content from the main view while retaining easy access to it in a dedicated "Read Issues" section. The design incorporates mobile-first UX principles for touch-friendly interactions and state persistence.

---
<a href="https://cursor.com/background-agent?bcId=bc-23e1f649-05af-4773-9e7a-860ed2dea8e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23e1f649-05af-4773-9e7a-860ed2dea8e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

