### PR TITLE
Investigate url removal cache bug

### DIFF
--- a/removed_urls.py
+++ b/removed_urls.py
@@ -26,7 +26,11 @@ def get_removed_urls() -> Set[str]:
         resp = requests.get(
             blob_url,
             timeout=10,
-            headers={"User-Agent": "Mozilla/5.0 (compatible; TLDR-Newsletter/1.0)"},
+            headers={
+                "User-Agent": "Mozilla/5.0 (compatible; TLDR-Newsletter/1.0)",
+                "Cache-Control": "no-cache, no-store, must-revalidate",
+                "Pragma": "no-cache",
+            },
         )
         resp.raise_for_status()
         util.log(


### PR DESCRIPTION
Add cache-busting headers to `get_removed_urls` to prevent Vercel's CDN from serving stale `removed-urls.json`.

Previously, after a URL was removed, immediate subsequent scrapes would sometimes show the URL as not removed due to the CDN serving a cached, outdated version of the `removed-urls.json` file. The added headers ensure the latest version is always fetched.

---
<a href="https://cursor.com/background-agent?bcId=bc-02a642a9-695b-4080-8f3e-40077f9df74c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02a642a9-695b-4080-8f3e-40077f9df74c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

