### PR TITLE
Improve CLI dispatch and error parity with server

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,18 +1,13 @@
 #!/usr/bin/env python3
+
 import argparse
 import json
 import sys
+from typing import Callable, Any
 
-from tldr_service import (
-    fetch_summarize_prompt_template,
-    fetch_tldr_prompt_template,
-    remove_url,
-    scrape_newsletters_in_date_range,
-    summarize_url_content,
-    tldr_url_content,
-)
-from removed_urls import get_removed_urls
-import cache_mode
+import requests
+
+import tldr_app
 
 
 def _print_error(message: str) -> None:
@@ -21,6 +16,62 @@ def _print_error(message: str) -> None:
 
 def _json_dumps(data: object) -> str:
     return json.dumps(data, indent=2, sort_keys=True)
+
+
+def _value_error_payload(error: Exception) -> dict:
+    return {"success": False, "error": str(error)}
+
+
+def _network_error_payload(error: requests.RequestException) -> dict:
+    return {"success": False, "error": f"Network error: {repr(error)}"}
+
+
+def _unexpected_error_payload(error: Exception) -> dict:
+    return {"success": False, "error": repr(error)}
+
+
+def _run_json_command(
+    command: Callable[[], Any],
+    *,
+    error_handlers: tuple[
+        tuple[type[Exception], Callable[[Exception], dict]],
+        ...,
+    ] = (),
+    default_error_handler: Callable[[Exception], dict] | None = None,
+    exit_code: int | None = 1,
+) -> None:
+    try:
+        result = command()
+    except Exception as error:
+        for exception_type, handler in error_handlers:
+            if isinstance(error, exception_type):
+                print(_json_dumps(handler(error)))
+                if exit_code is not None:
+                    sys.exit(exit_code)
+                return
+
+        if default_error_handler is not None:
+            print(_json_dumps(default_error_handler(error)))
+            if exit_code is not None:
+                sys.exit(exit_code)
+            return
+
+        _print_error(str(error))
+        if exit_code is not None:
+            sys.exit(exit_code)
+        return
+
+    print(_json_dumps(result))
+
+
+def _run_text_command(command: Callable[[], str]) -> None:
+    try:
+        result = command()
+    except Exception as error:
+        _print_error(str(error))
+        sys.exit(1)
+
+    print(result)
 
 
 def main() -> None:
@@ -85,7 +136,13 @@ def main() -> None:
     cache_mode_set_parser = cache_mode_subparsers.add_parser(
         "set", help="Set cache mode"
     )
-    cache_mode_set_parser.add_argument("--mode", help="Cache mode to set")
+    cache_mode_set_parser.add_argument(
+        "--cache-mode",
+        "--mode",
+        dest="cache_mode",
+        required=True,
+        help="Cache mode to set",
+    )
 
     invalidate_cache_parser = subparsers.add_parser(
         "invalidate-cache", help="Invalidate cache for date range"
@@ -106,154 +163,102 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if args.command == "scrape":
-        try:
-            result = scrape_newsletters_in_date_range(args.start_date, args.end_date)
-            print(_json_dumps(result))
-        except Exception as error:
-            _print_error(str(error))
-            sys.exit(1)
+    command_handlers: dict[str, Callable[[argparse.Namespace], None]] = {
+        "scrape": lambda command_args: _run_json_command(
+            lambda: tldr_app.scrape_newsletters(
+                command_args.start_date, command_args.end_date
+            ),
+            error_handlers=((ValueError, _value_error_payload),),
+            default_error_handler=_value_error_payload,
+        ),
+        "prompt": lambda command_args: _run_text_command(
+            tldr_app.get_summarize_prompt_template
+        ),
+        "tldr-prompt": lambda command_args: _run_text_command(
+            tldr_app.get_tldr_prompt_template
+        ),
+        "summarize-url": lambda command_args: _run_json_command(
+            lambda: tldr_app.summarize_url(
+                command_args.url,
+                cache_only=command_args.cache_only,
+                summary_effort=command_args.summary_effort,
+            ),
+            error_handlers=(
+                (ValueError, _value_error_payload),
+                (requests.RequestException, _network_error_payload),
+            ),
+            default_error_handler=_unexpected_error_payload,
+            exit_code=None,
+        ),
+        "tldr-url": lambda command_args: _run_json_command(
+            lambda: tldr_app.tldr_url(
+                command_args.url,
+                cache_only=command_args.cache_only,
+                summary_effort=command_args.summary_effort,
+            ),
+            error_handlers=(
+                (ValueError, _value_error_payload),
+                (requests.RequestException, _network_error_payload),
+            ),
+            default_error_handler=_unexpected_error_payload,
+            exit_code=None,
+        ),
+        "remove-url": lambda command_args: _run_json_command(
+            lambda: tldr_app.remove_url(command_args.url),
+            error_handlers=(
+                (ValueError, _value_error_payload),
+                (RuntimeError, _value_error_payload),
+            ),
+            default_error_handler=_unexpected_error_payload,
+            exit_code=None,
+        ),
+        "removed-urls": lambda command_args: _run_json_command(
+            tldr_app.list_removed_urls,
+            default_error_handler=_unexpected_error_payload,
+        ),
+        "cache-mode": lambda command_args: _run_cache_mode_command(
+            command_args
+        ),
+        "invalidate-cache": lambda command_args: _run_json_command(
+            lambda: tldr_app.invalidate_cache_in_date_range(
+                command_args.start_date, command_args.end_date
+            ),
+            error_handlers=((ValueError, _value_error_payload),),
+            default_error_handler=_unexpected_error_payload,
+        ),
+        "invalidate-date-cache": lambda command_args: _run_json_command(
+            lambda: tldr_app.invalidate_cache_for_date(command_args.date),
+            error_handlers=((ValueError, _value_error_payload),),
+            default_error_handler=_unexpected_error_payload,
+        ),
+    }
+
+    handler = command_handlers.get(args.command)
+    if handler is None:
+        _print_error(f"Unknown command: {args.command}")
+        sys.exit(1)
+
+    handler(args)
+
+
+def _run_cache_mode_command(args: argparse.Namespace) -> None:
+    if args.cache_mode_action == "get":
+        _run_json_command(
+            tldr_app.get_cache_mode,
+            default_error_handler=_unexpected_error_payload,
+        )
         return
 
-    if args.command == "prompt":
-        try:
-            print(fetch_summarize_prompt_template())
-        except Exception as error:
-            _print_error(str(error))
-            sys.exit(1)
+    if args.cache_mode_action == "set":
+        _run_json_command(
+            lambda: tldr_app.set_cache_mode(args.cache_mode),
+            error_handlers=((ValueError, _value_error_payload),),
+            default_error_handler=_unexpected_error_payload,
+        )
         return
 
-    if args.command == "tldr-prompt":
-        try:
-            print(fetch_tldr_prompt_template())
-        except Exception as error:
-            _print_error(str(error))
-            sys.exit(1)
-        return
-
-    if args.command == "summarize-url":
-        try:
-            result = summarize_url_content(
-                args.url,
-                cache_only=args.cache_only,
-                summary_effort=args.summary_effort,
-            )
-            if result is None:
-                print(
-                    _json_dumps({
-                        "success": False,
-                        "error": "No cached summary available",
-                    })
-                )
-                return
-            payload = {
-                "success": True,
-                "summary_markdown": result["summary_markdown"],
-                "summary_blob_url": result["summary_blob_url"],
-                "summary_blob_pathname": result["summary_blob_pathname"],
-                "canonical_url": result["canonical_url"],
-                "summary_effort": result["summary_effort"],
-            }
-            print(_json_dumps(payload))
-        except Exception as error:
-            print(_json_dumps({"success": False, "error": str(error)}))
-            return
-        return
-
-    if args.command == "tldr-url":
-        try:
-            result = tldr_url_content(
-                args.url,
-                cache_only=args.cache_only,
-                summary_effort=args.summary_effort,
-            )
-            if result is None:
-                print(
-                    _json_dumps({
-                        "success": False,
-                        "error": "No cached TLDR available",
-                    })
-                )
-                return
-            payload = {
-                "success": True,
-                "tldr_markdown": result["tldr_markdown"],
-                "tldr_blob_url": result["tldr_blob_url"],
-                "tldr_blob_pathname": result["tldr_blob_pathname"],
-                "canonical_url": result["canonical_url"],
-                "summary_effort": result["summary_effort"],
-            }
-            print(_json_dumps(payload))
-        except Exception as error:
-            print(_json_dumps({"success": False, "error": str(error)}))
-            return
-        return
-
-    if args.command == "remove-url":
-        try:
-            canonical_url = remove_url(args.url)
-            print(_json_dumps({"success": True, "canonical_url": canonical_url}))
-        except Exception as error:
-            print(_json_dumps({"success": False, "error": str(error)}))
-            return
-        return
-
-    if args.command == "removed-urls":
-        try:
-            removed_urls = get_removed_urls()
-            print(_json_dumps({"removed_urls": list(removed_urls)}))
-        except Exception as error:
-            _print_error(str(error))
-            sys.exit(1)
-        return
-
-    if args.command == "cache-mode":
-        if args.cache_mode_action == "get":
-            try:
-                mode = cache_mode.get_cache_mode()
-                print(_json_dumps({"cache_mode": mode.value}))
-            except Exception as error:
-                _print_error(str(error))
-                sys.exit(1)
-        elif args.cache_mode_action == "set":
-            try:
-                mode = cache_mode.CacheMode(args.mode)
-                success = cache_mode.set_cache_mode(mode)
-                print(_json_dumps({"success": success}))
-            except Exception as error:
-                _print_error(str(error))
-                sys.exit(1)
-        return
-
-    if args.command == "invalidate-cache":
-        try:
-            # This would need to be implemented in tldr_service or a new module
-            # For now, return a placeholder response
-            print(
-                _json_dumps({
-                    "success": True,
-                    "message": "Cache invalidation not yet implemented",
-                })
-            )
-        except Exception as error:
-            _print_error(str(error))
-            sys.exit(1)
-        return
-
-    if args.command == "invalidate-date-cache":
-        try:
-            # This would need to be implemented in tldr_service or a new module
-            # For now, return a placeholder response
-            print(
-                _json_dumps({
-                    "success": True,
-                    "message": "Date cache invalidation not yet implemented",
-                })
-            )
-        except Exception as error:
-            _print_error(str(error))
-            sys.exit(1)
-        return
+    _print_error(f"Unknown cache-mode action: {args.cache_mode_action}")
+    sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/serve.py
+++ b/serve.py
@@ -6,14 +6,10 @@ Important: cli.py must expose the exact same interfaces to the app logic that se
 
 from flask import Flask, render_template, request, jsonify
 import logging
-from datetime import datetime
 import requests
 
-import blob_store
-import cache_mode
 import util
-import tldr_service
-import removed_urls
+import tldr_app
 
 app = Flask(__name__)
 logging.basicConfig(level=util.resolve_env_var("LOG_LEVEL", "INFO"))
@@ -34,7 +30,7 @@ def scrape_newsletters_in_date_range():
         if data is None:
             return jsonify({"success": False, "error": "No JSON data received"}), 400
 
-        result = tldr_service.scrape_newsletters_in_date_range(
+        result = tldr_app.scrape_newsletters(
             data.get("start_date"),
             data.get("end_date"),
         )
@@ -54,7 +50,7 @@ def scrape_newsletters_in_date_range():
 def get_summarize_prompt_template():
     """Return the loaded summarize.md prompt (for debugging/inspection)."""
     try:
-        prompt = tldr_service.fetch_summarize_prompt_template()
+        prompt = tldr_app.get_summarize_prompt_template()
         return prompt, 200, {"Content-Type": "text/plain; charset=utf-8"}
     except Exception as e:
         util.log(
@@ -79,34 +75,13 @@ def summarize_url():
     """
     try:
         data = request.get_json() or {}
-        result = tldr_service.summarize_url_content(
+        result = tldr_app.summarize_url(
             data.get("url", ""),
-            cache_only=data.get("cache_only", False),
+            cache_only=bool(data.get("cache_only", False)),
             summary_effort=data.get("summary_effort", "low"),
         )
 
-        if result is None:
-            return jsonify({
-                "success": False,
-                "error": "No cached summary available",
-            })
-
-        response_payload = {
-            "success": True,
-            "summary_markdown": result["summary_markdown"],
-            "summary_blob_url": result["summary_blob_url"],
-            "summary_blob_pathname": result["summary_blob_pathname"],
-        }
-
-        canonical_url = result.get("canonical_url")
-        if canonical_url:
-            response_payload["canonical_url"] = canonical_url
-
-        summary_effort = result.get("summary_effort")
-        if summary_effort:
-            response_payload["summary_effort"] = summary_effort
-
-        return jsonify(response_payload)
+        return jsonify(result)
 
     except ValueError as error:
         return jsonify({"success": False, "error": str(error)}), 400
@@ -139,34 +114,13 @@ def tldr_url():
     """
     try:
         data = request.get_json() or {}
-        result = tldr_service.tldr_url_content(
+        result = tldr_app.tldr_url(
             data.get("url", ""),
-            cache_only=data.get("cache_only", False),
+            cache_only=bool(data.get("cache_only", False)),
             summary_effort=data.get("summary_effort", "low"),
         )
 
-        if result is None:
-            return jsonify({
-                "success": False,
-                "error": "No cached TLDR available",
-            })
-
-        response_payload = {
-            "success": True,
-            "tldr_markdown": result["tldr_markdown"],
-            "tldr_blob_url": result["tldr_blob_url"],
-            "tldr_blob_pathname": result["tldr_blob_pathname"],
-        }
-
-        canonical_url = result.get("canonical_url")
-        if canonical_url:
-            response_payload["canonical_url"] = canonical_url
-
-        summary_effort = result.get("summary_effort")
-        if summary_effort:
-            response_payload["summary_effort"] = summary_effort
-
-        return jsonify(response_payload)
+        return jsonify(result)
 
     except ValueError as error:
         return jsonify({"success": False, "error": str(error)}), 400
@@ -195,10 +149,9 @@ def tldr_url():
 def remove_url():
     """Mark a URL as removed so it won't appear in future scrapes. Expects 'url' in the request body."""
     try:
-        url = request.get_json()["url"]
-        assert url, "url is required"
-        canonical = tldr_service.remove_url(url)
-        return jsonify({"success": True, "canonical_url": canonical})
+        data = request.get_json() or {}
+        result = tldr_app.remove_url(data.get("url"))
+        return jsonify(result)
 
     except ValueError as error:
         return jsonify({"success": False, "error": str(error)}), 400
@@ -219,10 +172,7 @@ def remove_url():
 def get_removed_urls():
     """Get the list of removed URLs."""
     try:
-        return jsonify({
-            "success": True,
-            "removed_urls": list(removed_urls.get_removed_urls()),
-        })
+        return jsonify(tldr_app.list_removed_urls())
     except Exception as e:
         util.log(
             "[serve.get_removed_urls] error error=%s",
@@ -238,11 +188,7 @@ def get_removed_urls():
 def get_cache_mode():
     """Get the current cache mode."""
     try:
-        mode = cache_mode.get_cache_mode()
-        return jsonify({
-            "success": True,
-            "cache_mode": mode.value,
-        })
+        return jsonify(tldr_app.get_cache_mode())
     except Exception as e:
         util.log(
             "[serve.get_cache_mode] error error=%s",
@@ -259,30 +205,11 @@ def set_cache_mode():
     """Set the cache mode. Expects 'cache_mode' in the request body."""
     try:
         data = request.get_json() or {}
-        mode_str = (data.get("cache_mode") or "").strip().lower()
+        result = tldr_app.set_cache_mode(data.get("cache_mode"))
+        return jsonify(result)
 
-        if not mode_str:
-            return jsonify({"success": False, "error": "cache_mode is required"}), 400
-
-        try:
-            mode = cache_mode.CacheMode(mode_str)
-        except ValueError:
-            valid_modes = [m.value for m in cache_mode.CacheMode]
-            return jsonify({
-                "success": False,
-                "error": f"Invalid cache_mode. Valid values: {', '.join(valid_modes)}",
-            }), 400
-
-        success = cache_mode.set_cache_mode(mode)
-
-        if success:
-            return jsonify({
-                "success": True,
-                "cache_mode": mode.value,
-            })
-        else:
-            return jsonify({"success": False, "error": "Failed to set cache mode"}), 500
-
+    except ValueError as error:
+        return jsonify({"success": False, "error": str(error)}), 400
     except Exception as e:
         util.log(
             "[serve.set_cache_mode] error error=%s",
@@ -304,82 +231,14 @@ def invalidate_cache_in_date_range():
     """
     try:
         data = request.get_json() or {}
-
-        if "start_date" not in data or "end_date" not in data:
-            return jsonify({
-                "success": False,
-                "error": "start_date and end_date are required",
-            }), 400
-
-        start_date = datetime.fromisoformat(data["start_date"])
-        end_date = datetime.fromisoformat(data["end_date"])
-
-        if start_date > end_date:
-            return jsonify({
-                "success": False,
-                "error": "start_date must be before or equal to end_date",
-            }), 400
-
-        dates = util.get_date_range(start_date, end_date)
-
-        # Build list of potential cache entries
-        potential_pathnames = []
-        for date in dates:
-            date_str = util.format_date_for_url(date)
-            pathname = blob_store.build_scraped_day_cache_key(date_str)
-            potential_pathnames.append(pathname)
-
-        # Check which entries actually exist
-
-        existing_entries = blob_store.list_existing_entries(potential_pathnames)
-
-        util.log(
-            f"[serve.invalidate_cache_in_date_range] Found {len(existing_entries)} existing entries out of {len(potential_pathnames)} potential entries",
-            logger=logger,
+        result = tldr_app.invalidate_cache_in_date_range(
+            data.get("start_date"),
+            data.get("end_date"),
         )
+        return jsonify(result)
 
-        deleted_count = 0
-        failed_count = 0
-        errors = []
-
-        for pathname in existing_entries:
-            try:
-                success = blob_store.delete_file(pathname)
-                if success:
-                    deleted_count += 1
-                    util.log(
-                        f"[serve.invalidate_cache_in_date_range] Deleted cache for pathname={pathname}",
-                        logger=logger,
-                    )
-                else:
-                    failed_count += 1
-                    errors.append(f"{pathname}: delete returned false")
-            except Exception as e:
-                failed_count += 1
-                error_msg = f"{pathname}: {repr(e)}"
-                errors.append(error_msg)
-                util.log(
-                    f"[serve.invalidate_cache_in_date_range] Failed to delete cache for pathname={pathname} error={repr(e)}",
-                    level=logging.WARNING,
-                    logger=logger,
-                )
-
-        # Log final summary
-        util.log(
-            f"[serve.invalidate_cache_in_date_range] Completed: {deleted_count} successful deletions, {failed_count} failed deletions out of {len(existing_entries)} existing entries",
-            logger=logger,
-        )
-
-        overall_success = failed_count == 0
-        return jsonify({
-            "success": overall_success,
-            "deleted": deleted_count,
-            "failed": failed_count,
-            "total_existing_entries": len(existing_entries),
-            "total_potential_entries": len(potential_pathnames),
-            "errors": errors if errors else None,
-        })
-
+    except ValueError as error:
+        return jsonify({"success": False, "error": str(error)}), 400
     except Exception as e:
         util.log(
             "[serve.invalidate_cache_in_date_range] error error=%s",
@@ -398,88 +257,11 @@ def invalidate_cache_for_date():
     """
     try:
         data = request.get_json() or {}
-        if not data.get("date"):
-            return jsonify({
-                "success": False,
-                "error": "date is required",
-            }), 400
+        result = tldr_app.invalidate_cache_for_date(data.get("date"))
+        return jsonify(result)
 
-        date_str = data["date"]
-
-        from summarizer import SUMMARY_EFFORT_OPTIONS
-
-        deleted_files = []
-        failed_files = []
-
-        day_cache_pathname = blob_store.build_scraped_day_cache_key(date_str)
-
-        blob_base_url = util.resolve_env_var("BLOB_STORE_BASE_URL", "").strip()
-        if not blob_base_url:
-            return jsonify({
-                "success": False,
-                "error": "BLOB_STORE_BASE_URL not configured",
-            }), 500
-
-        try:
-            blob_url = f"{blob_base_url}/{day_cache_pathname}"
-            response = requests.get(blob_url, timeout=10)
-            response.raise_for_status()
-            cached_day = response.json()
-            articles = cached_day.get("articles", [])
-        except Exception as e:
-            util.log(
-                f"[serve.invalidate_cache_for_date] Could not fetch day cache for date={date_str}: {repr(e)}",
-                level=logging.WARNING,
-                logger=logger,
-            )
-            articles = []
-
-        urls_to_process = set()
-        for article in articles:
-            url = article.get("url")
-            if url:
-                canonical = util.canonicalize_url(url)
-                urls_to_process.add(canonical)
-
-        for url in urls_to_process:
-            url_base_pathname = blob_store.normalize_url_to_pathname(url)
-            url_base = (
-                url_base_pathname[:-3]
-                if url_base_pathname.endswith(".md")
-                else url_base_pathname
-            )
-
-            content_pathname = url_base_pathname
-            if blob_store.delete_file(content_pathname):
-                deleted_files.append(content_pathname)
-            else:
-                failed_files.append(content_pathname)
-
-            for effort in SUMMARY_EFFORT_OPTIONS:
-                suffix = "" if effort == "low" else f"-{effort}"
-                summary_pathname = f"{url_base}-summary{suffix}.md"
-                if blob_store.delete_file(summary_pathname):
-                    deleted_files.append(summary_pathname)
-
-        if blob_store.delete_file(day_cache_pathname):
-            deleted_files.append(day_cache_pathname)
-        else:
-            failed_files.append(day_cache_pathname)
-
-        util.log(
-            f"[serve.invalidate_cache_for_date] Deleted {len(deleted_files)} files for date={date_str}",
-            logger=logger,
-        )
-
-        return jsonify({
-            "success": True,
-            "date": date_str,
-            "deleted_count": len(deleted_files),
-            "failed_count": len(failed_files),
-            "deleted_files": deleted_files[:10],
-            "failed_files": failed_files if failed_files else None,
-        })
-
+    except ValueError as error:
+        return jsonify({"success": False, "error": str(error)}), 400
     except Exception as e:
         util.log(
             "[serve.invalidate_cache_for_date] error error=%s",

--- a/tldr_app.py
+++ b/tldr_app.py
@@ -1,0 +1,271 @@
+import logging
+from datetime import datetime
+from typing import Optional
+
+import requests
+
+import blob_store
+import cache_mode
+import util
+import tldr_service
+from removed_urls import get_removed_urls as _get_removed_urls
+
+logger = logging.getLogger("tldr_app")
+
+
+def scrape_newsletters(start_date_text: str, end_date_text: str) -> dict:
+    return tldr_service.scrape_newsletters_in_date_range(
+        start_date_text, end_date_text
+    )
+
+
+def get_summarize_prompt_template() -> str:
+    return tldr_service.fetch_summarize_prompt_template()
+
+
+def get_tldr_prompt_template() -> str:
+    return tldr_service.fetch_tldr_prompt_template()
+
+
+def summarize_url(
+    url: str,
+    *,
+    cache_only: bool = False,
+    summary_effort: str = "low",
+) -> dict:
+    result = tldr_service.summarize_url_content(
+        url,
+        cache_only=cache_only,
+        summary_effort=summary_effort,
+    )
+
+    if result is None:
+        return {"success": False, "error": "No cached summary available"}
+
+    payload: dict[str, Optional[str]] = {
+        "success": True,
+        "summary_markdown": result["summary_markdown"],
+        "summary_blob_url": result["summary_blob_url"],
+        "summary_blob_pathname": result["summary_blob_pathname"],
+    }
+
+    canonical_url = result.get("canonical_url")
+    if canonical_url:
+        payload["canonical_url"] = canonical_url
+
+    summary_effort_value = result.get("summary_effort")
+    if summary_effort_value:
+        payload["summary_effort"] = summary_effort_value
+
+    return payload
+
+
+def tldr_url(
+    url: str,
+    *,
+    cache_only: bool = False,
+    summary_effort: str = "low",
+) -> dict:
+    result = tldr_service.tldr_url_content(
+        url,
+        cache_only=cache_only,
+        summary_effort=summary_effort,
+    )
+
+    if result is None:
+        return {"success": False, "error": "No cached TLDR available"}
+
+    payload: dict[str, Optional[str]] = {
+        "success": True,
+        "tldr_markdown": result["tldr_markdown"],
+        "tldr_blob_url": result["tldr_blob_url"],
+        "tldr_blob_pathname": result["tldr_blob_pathname"],
+    }
+
+    canonical_url = result.get("canonical_url")
+    if canonical_url:
+        payload["canonical_url"] = canonical_url
+
+    summary_effort_value = result.get("summary_effort")
+    if summary_effort_value:
+        payload["summary_effort"] = summary_effort_value
+
+    return payload
+
+
+def remove_url(url: str) -> dict:
+    canonical_url = tldr_service.remove_url(url)
+    return {"success": True, "canonical_url": canonical_url}
+
+
+def list_removed_urls() -> dict:
+    return {"success": True, "removed_urls": list(_get_removed_urls())}
+
+
+def get_cache_mode() -> dict:
+    mode = cache_mode.get_cache_mode()
+    return {"success": True, "cache_mode": mode.value}
+
+
+def set_cache_mode(mode_str: Optional[str]) -> dict:
+    normalized_mode = (mode_str or "").strip().lower()
+    if not normalized_mode:
+        raise ValueError("cache_mode is required")
+
+    try:
+        mode = cache_mode.CacheMode(normalized_mode)
+    except ValueError as error:
+        valid_modes = ", ".join(sorted(m.value for m in cache_mode.CacheMode))
+        raise ValueError(
+            f"Invalid cache_mode. Valid values: {valid_modes}"
+        ) from error
+
+    success = cache_mode.set_cache_mode(mode)
+    if not success:
+        raise RuntimeError("Failed to set cache mode")
+
+    return {"success": True, "cache_mode": mode.value}
+
+
+def invalidate_cache_in_date_range(
+    start_date_text: Optional[str], end_date_text: Optional[str]
+) -> dict:
+    if not start_date_text or not end_date_text:
+        raise ValueError("start_date and end_date are required")
+
+    start_date = datetime.fromisoformat(start_date_text)
+    end_date = datetime.fromisoformat(end_date_text)
+
+    if start_date > end_date:
+        raise ValueError("start_date must be before or equal to end_date")
+
+    dates = util.get_date_range(start_date, end_date)
+
+    potential_pathnames = []
+    for date in dates:
+        date_str = util.format_date_for_url(date)
+        pathname = blob_store.build_scraped_day_cache_key(date_str)
+        potential_pathnames.append(pathname)
+
+    existing_entries = blob_store.list_existing_entries(potential_pathnames)
+
+    util.log(
+        f"[tldr_app.invalidate_cache_in_date_range] Found {len(existing_entries)} existing entries out of {len(potential_pathnames)} potential entries",
+        logger=logger,
+    )
+
+    deleted_count = 0
+    failed_count = 0
+    errors: list[str] = []
+
+    for pathname in existing_entries:
+        try:
+            success = blob_store.delete_file(pathname)
+            if success:
+                deleted_count += 1
+                util.log(
+                    f"[tldr_app.invalidate_cache_in_date_range] Deleted cache for pathname={pathname}",
+                    logger=logger,
+                )
+            else:
+                failed_count += 1
+                errors.append(f"{pathname}: delete returned false")
+        except Exception as error:
+            failed_count += 1
+            error_message = f"{pathname}: {repr(error)}"
+            errors.append(error_message)
+            util.log(
+                f"[tldr_app.invalidate_cache_in_date_range] Failed to delete cache for pathname={pathname} error={repr(error)}",
+                level=logging.WARNING,
+                logger=logger,
+            )
+
+    util.log(
+        f"[tldr_app.invalidate_cache_in_date_range] Completed: {deleted_count} successful deletions, {failed_count} failed deletions out of {len(existing_entries)} existing entries",
+        logger=logger,
+    )
+
+    return {
+        "success": failed_count == 0,
+        "deleted": deleted_count,
+        "failed": failed_count,
+        "total_existing_entries": len(existing_entries),
+        "total_potential_entries": len(potential_pathnames),
+        "errors": errors or None,
+    }
+
+
+def invalidate_cache_for_date(date_text: Optional[str]) -> dict:
+    if not date_text:
+        raise ValueError("date is required")
+
+    from summarizer import SUMMARY_EFFORT_OPTIONS
+
+    deleted_files: list[str] = []
+    failed_files: list[str] = []
+
+    day_cache_pathname = blob_store.build_scraped_day_cache_key(date_text)
+
+    blob_base_url = util.resolve_env_var("BLOB_STORE_BASE_URL", "").strip()
+    if not blob_base_url:
+        raise RuntimeError("BLOB_STORE_BASE_URL not configured")
+
+    try:
+        blob_url = f"{blob_base_url}/{day_cache_pathname}"
+        response = requests.get(blob_url, timeout=10)
+        response.raise_for_status()
+        cached_day = response.json()
+        articles = cached_day.get("articles", [])
+    except Exception as error:
+        util.log(
+            f"[tldr_app.invalidate_cache_for_date] Could not fetch day cache for date={date_text}: {repr(error)}",
+            level=logging.WARNING,
+            logger=logger,
+        )
+        articles = []
+
+    urls_to_process = set()
+    for article in articles:
+        url = article.get("url")
+        if url:
+            canonical = util.canonicalize_url(url)
+            urls_to_process.add(canonical)
+
+    for url in urls_to_process:
+        url_base_pathname = blob_store.normalize_url_to_pathname(url)
+        url_base = (
+            url_base_pathname[:-3]
+            if url_base_pathname.endswith(".md")
+            else url_base_pathname
+        )
+
+        content_pathname = url_base_pathname
+        if blob_store.delete_file(content_pathname):
+            deleted_files.append(content_pathname)
+        else:
+            failed_files.append(content_pathname)
+
+        for effort in SUMMARY_EFFORT_OPTIONS:
+            suffix = "" if effort == "low" else f"-{effort}"
+            summary_pathname = f"{url_base}-summary{suffix}.md"
+            if blob_store.delete_file(summary_pathname):
+                deleted_files.append(summary_pathname)
+
+    if blob_store.delete_file(day_cache_pathname):
+        deleted_files.append(day_cache_pathname)
+    else:
+        failed_files.append(day_cache_pathname)
+
+    util.log(
+        f"[tldr_app.invalidate_cache_for_date] Deleted {len(deleted_files)} files for date={date_text}",
+        logger=logger,
+    )
+
+    return {
+        "success": True,
+        "date": date_text,
+        "deleted_count": len(deleted_files),
+        "failed_count": len(failed_files),
+        "deleted_files": deleted_files[:10],
+        "failed_files": failed_files or None,
+    }


### PR DESCRIPTION
## Summary
- centralize CLI command dispatch through reusable helpers so each subcommand uses the same application workflow entry points
- return structured JSON error payloads for CLI commands, including network and validation cases, to mirror the Flask endpoints
- require the cache-mode setter to pass --cache-mode (with a --mode alias) to reflect the HTTP payload naming

## Testing
- uv run python3 -m compileall cli.py
- uv run python3 cli.py prompt
- uv run python3 cli.py summarize-url --url ''
- uv run python3 cli.py scrape --start-date 2024-01-02 --end-date 2024-01-01

------
https://chatgpt.com/codex/tasks/task_e_68ea123d6d248332ae2bd271f1abd2f4