### PR TITLE
Enable issue header toggle for collapsing content

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -822,6 +822,20 @@
             margin: 0 !important;
             flex: 1;
             font-style: normal !important;
+            transition: color 0.2s ease, opacity 0.2s ease;
+        }
+
+        .issue-header-container h4[data-issue-toggle] {
+            cursor: pointer;
+        }
+
+        .issue-header-container h4[data-issue-toggle]:hover,
+        .issue-header-container h4[data-issue-toggle]:focus-visible {
+            color: #1a73e8;
+        }
+
+        .issue-header-container[data-collapse-mode="in-place"] h4[data-issue-toggle] {
+            opacity: 0.75;
         }
 
         .issue-header-container .mark-read-btn {
@@ -2000,11 +2014,26 @@
                                 container.setAttribute('data-category', categoryText);
                             }
 
+                            let issueKey = null;
+                            if (currentDate && categoryText) {
+                                issueKey = getIssueKey(currentDate, categoryText);
+                                if (issueKey) {
+                                    container.setAttribute('data-issue-key', issueKey);
+                                }
+                            }
+
+                            newHeader.setAttribute('data-issue-toggle', issueKey || '');
+                            newHeader.setAttribute('data-issue-toggle-action', 'toggle');
+                            newHeader.setAttribute('tabindex', '0');
+                            newHeader.setAttribute('aria-expanded', 'true');
+
                             const markReadBtn = document.createElement('button');
                             markReadBtn.className = 'mark-read-btn';
                             markReadBtn.textContent = 'Mark as Read';
                             markReadBtn.title = 'Collapse and move to bottom';
                             markReadBtn.type = 'button';
+                            markReadBtn.setAttribute('data-issue-toggle-action', 'mark-read');
+                            markReadBtn.setAttribute('data-issue-toggle', issueKey || '');
 
                             container.appendChild(newHeader);
                             container.appendChild(markReadBtn);
@@ -2443,6 +2472,103 @@
         // #endregion
 
         /**
+         * IssueCollapseManager normalizes collapsing behavior across issue headers, mark-as-read controls, and titles.
+         */
+        // #region -------[ IssueCollapseManager ]-------
+        function escapeIssueKeySelector(issueKey) {
+            if (typeof issueKey !== 'string') return issueKey;
+            if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+                return CSS.escape(issueKey);
+            }
+            return issueKey.replace(/(["'\\])/g, '\\$1');
+        }
+
+        function findIssueContainer(issueKey, toggleEl) {
+            if (issueKey) {
+                const escapedKey = escapeIssueKeySelector(issueKey);
+                const container = document.querySelector(`.issue-header-container[data-issue-key="${escapedKey}"]`);
+                if (container) return container;
+            }
+            if (toggleEl) {
+                const container = toggleEl.closest('.issue-header-container');
+                if (container) return container;
+            }
+            return null;
+        }
+
+        function getIssueContentNodes(container) {
+            if (!container) return [];
+            const nodes = [];
+            let node = container.nextElementSibling;
+            while (node && !node.classList.contains('issue-header-container') && !node.classList.contains('date-header-container')) {
+                nodes.push(node);
+                node = node.nextElementSibling;
+            }
+            return nodes;
+        }
+
+        function collapseIssueContent(container, options = {}) {
+            if (!container) return;
+            const mode = options.mode || 'in-place';
+            const currentMode = container.getAttribute('data-collapse-mode');
+            if (currentMode === mode) return;
+            if (currentMode === 'marked-read' && mode !== 'marked-read') return;
+
+            const nodes = getIssueContentNodes(container);
+            nodes.forEach(node => {
+                if (node.dataset.issueDisplay === undefined) {
+                    node.dataset.issueDisplay = node.style.display || '';
+                }
+                node.style.display = 'none';
+                node.setAttribute('data-collapsed', 'true');
+            });
+
+            container.setAttribute('data-collapsed', 'true');
+            container.setAttribute('data-collapse-mode', mode);
+
+            const header = container.querySelector('h4[data-issue-toggle]');
+            if (header) {
+                header.setAttribute('aria-expanded', 'false');
+            }
+        }
+
+        function expandIssueContent(container) {
+            if (!container) return;
+            if (container.getAttribute('data-collapse-mode') !== 'in-place') return;
+
+            const nodes = getIssueContentNodes(container);
+            nodes.forEach(node => {
+                if (node.dataset.issueDisplay !== undefined) {
+                    node.style.display = node.dataset.issueDisplay;
+                    delete node.dataset.issueDisplay;
+                } else {
+                    node.style.removeProperty('display');
+                }
+                node.removeAttribute('data-collapsed');
+            });
+
+            container.removeAttribute('data-collapsed');
+            container.removeAttribute('data-collapse-mode');
+
+            const header = container.querySelector('h4[data-issue-toggle]');
+            if (header) {
+                header.setAttribute('aria-expanded', 'true');
+            }
+        }
+
+        function toggleIssueContent(container) {
+            if (!container) return;
+            const mode = container.getAttribute('data-collapse-mode');
+            if (mode === 'marked-read') return;
+            if (mode === 'in-place') {
+                expandIssueContent(container);
+                return;
+            }
+            collapseIssueContent(container, { mode: 'in-place' });
+        }
+        // #endregion
+
+        /**
          * IssueDayReadState manages collapsible read state for entire issue-days with localStorage persistence.
          */
         // #region -------[ IssueDayReadState ]-------
@@ -2478,7 +2604,12 @@
         function markIssueAsRead(container) {
             try {
                 console.log('markIssueAsRead called', {show: true});
-                
+
+                if (!container || container.getAttribute('data-collapse-mode') === 'marked-read') {
+                    console.log('Issue already marked as read or container missing', {show: true});
+                    return;
+                }
+
                 const header = container.querySelector('h4');
                 if (!header) {
                     console.error('No h4 found in container', {show: true});
@@ -2501,39 +2632,41 @@
                 
                 const collapsedSection = ensureCollapsedSection();
                 const issueContent = extractIssueContent(container);
-                
+
                 const collapsedIssue = document.createElement('div');
                 collapsedIssue.className = 'collapsed-issue';
                 collapsedIssue.setAttribute('data-issue-key', issueKey);
-                
+
                 const headerContainer = document.createElement('div');
                 headerContainer.className = 'collapsed-issue-header';
-                
+
                 const title = document.createElement('div');
                 title.className = 'collapsed-issue-title';
                 title.textContent = headerText + ' – ' + date;
-                
+
                 const markReadBtn = document.createElement('button');
                 markReadBtn.className = 'mark-read-btn';
                 markReadBtn.textContent = 'Mark as Read';
                 markReadBtn.title = 'Collapse and move to bottom';
                 markReadBtn.type = 'button';
-                
+                markReadBtn.setAttribute('data-issue-toggle-action', 'mark-read');
+                markReadBtn.setAttribute('data-issue-toggle', issueKey || '');
+
                 headerContainer.appendChild(title);
                 headerContainer.appendChild(markReadBtn);
-                
+
                 const contentWrapper = document.createElement('div');
                 contentWrapper.className = 'collapsed-issue-content';
                 contentWrapper.appendChild(issueContent);
                 
                 collapsedIssue.appendChild(headerContainer);
                 collapsedIssue.appendChild(contentWrapper);
-                
+
                 collapsedSection.appendChild(collapsedIssue);
-                
+
+                collapseIssueContent(container, { mode: 'marked-read' });
                 container.style.display = 'none';
-                container.setAttribute('data-collapsed', 'true');
-                
+
                 setIssueRead(issueKey, true);
                 console.log('Issue marked as read successfully', {show: true});
             } catch (error) {
@@ -2543,17 +2676,10 @@
 
         function extractIssueContent(container) {
             const content = document.createElement('div');
-            let node = container.nextElementSibling;
-            
-            while (node && !node.classList.contains('issue-header-container') && !node.classList.contains('date-header-container')) {
-                const clone = node.cloneNode(true);
-                content.appendChild(clone);
-                const nextNode = node.nextElementSibling;
-                node.style.display = 'none';
-                node.setAttribute('data-collapsed', 'true');
-                node = nextNode;
-            }
-            
+            const nodes = getIssueContentNodes(container);
+            nodes.forEach(node => {
+                content.appendChild(node.cloneNode(true));
+            });
             return content;
         }
 
@@ -2591,33 +2717,59 @@
             });
         }
 
-        function bindMarkAsReadButtons() {
-            document.addEventListener('click', function(e) {
-                const btn = e.target.closest('.mark-read-btn');
-                if (!btn) return;
-                
-                e.preventDefault();
-                e.stopPropagation();
-                
-                try {
-                    const issueContainer = btn.closest('.issue-header-container');
-                    if (issueContainer) {
+        function bindIssueToggleControls() {
+            function handleIssueToggle(element, event) {
+                const action = element.getAttribute('data-issue-toggle-action') || 'toggle';
+                const issueKey = element.getAttribute('data-issue-toggle');
+                const issueContainer = findIssueContainer(issueKey, element);
+
+                if (action === 'toggle') {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    if (!issueContainer) return;
+                    toggleIssueContent(issueContainer);
+                    return;
+                }
+
+                if (action === 'mark-read') {
+                    event.preventDefault();
+                    event.stopPropagation();
+
+                    const collapsedIssue = element.closest('.collapsed-issue');
+
+                    if (issueContainer && issueContainer.getAttribute('data-collapse-mode') !== 'marked-read') {
                         console.log('Marking issue as read from header:', issueContainer);
                         markIssueAsRead(issueContainer);
                         return;
                     }
-                    
-                    const collapsedIssue = btn.closest('.collapsed-issue');
+
                     if (collapsedIssue) {
                         console.log('Collapsing expanded read issue', {show: true});
                         collapsedIssue.classList.remove('expanded');
                         return;
                     }
-                    
+
+                    if (issueContainer) {
+                        console.log('Mark as read clicked but issue already collapsed', {show: true});
+                        return;
+                    }
+
                     console.log('Mark as read clicked but no container found', {show: true});
-                } catch (error) {
-                    console.error('Error in mark as read handler:', error, {show: true});
                 }
+            }
+
+            document.addEventListener('click', function(e) {
+                const toggleEl = e.target.closest('[data-issue-toggle]');
+                if (!toggleEl) return;
+                handleIssueToggle(toggleEl, e);
+            });
+
+            document.addEventListener('keydown', function(e) {
+                if (e.key !== 'Enter' && e.key !== ' ') return;
+                const toggleEl = e.target.closest('[data-issue-toggle]');
+                if (!toggleEl) return;
+                if (toggleEl.tagName === 'BUTTON') return;
+                handleIssueToggle(toggleEl, e);
             });
         }
 
@@ -2657,7 +2809,7 @@
         bindSummaryExpansion();
         bindTldrExpansion();
         bindCollapsedIssueClick();
-        bindMarkAsReadButtons();
+        bindIssueToggleControls();
         // #endregion
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add a reusable issue collapse manager so headers and buttons can target specific sections
- wire mark-as-read controls through the shared collapse logic while keeping read state persistence intact
- expose issue titles as focusable toggles and refresh styling for the new interaction

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ecf7892d3c8332864ec55363e64e5a