### PR TITLE
Verify removed URL persistence after writes

### DIFF
--- a/removed_urls.py
+++ b/removed_urls.py
@@ -59,6 +59,18 @@ def add_removed_url(url: str) -> bool:
             f"[removed_urls.add_removed_url] Added url={url} pathname={REMOVED_URLS_PATHNAME}",
             logger=logger,
         )
+        persisted_removed = get_removed_urls()
+        if url in persisted_removed:
+            util.log(
+                f"[removed_urls.add_removed_url] ✓ Verified url={url} persisted in pathname={REMOVED_URLS_PATHNAME}",
+                logger=logger,
+            )
+        else:
+            util.log(
+                f"[removed_urls.add_removed_url] Unable to verify url={url} persisted in pathname={REMOVED_URLS_PATHNAME}",
+                level=logging.WARNING,
+                logger=logger,
+            )
         return True
     except Exception as e:
         util.log(


### PR DESCRIPTION
## Summary
- add a verification read after persisting a removed URL to the blob store
- log a checkmarked info message when the URL is present and warn when it is missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed509fc03083329cdb9dfaf0e47782