### PR TITLE
Refine trash can icon proportions

### DIFF
--- a/static/icons/trash.svg
+++ b/static/icons/trash.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <symbol id="trash-icon" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4.5 7h15"/>
+      <path d="M9.5 7V5.25A1.75 1.75 0 0 1 11.25 3.5h1.5A1.75 1.75 0 0 1 14.5 5.25V7"/>
+      <path d="M8.2 7l.72 11.58A2.3 2.3 0 0 0 11.19 20.7h1.62a2.3 2.3 0 0 0 2.27-2.12L15.8 7"/>
+      <path d="M11.75 11v6"/>
+    </g>
+  </symbol>
+</svg>

--- a/templates/index.html
+++ b/templates/index.html
@@ -701,6 +701,8 @@
         .article-btn svg {
             width: 18px;
             height: 18px;
+            display: block;
+            color: inherit;
         }
 
         .article-btn.remove-btn {
@@ -1604,6 +1606,7 @@
          */
         // #region -------[ SummaryClipboard ]-------
         const clipboardIconMarkup = '<svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+        const trashIconMarkup = `<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" class="icon-trash"><use href="{{ url_for('static', filename='icons/trash.svg#trash-icon') }}"></use></svg>`;
         const copyToast = document.getElementById('copyToast');
         let copyToastTimeout;
 
@@ -2416,8 +2419,9 @@
 
                                 const removeBtn = document.createElement('button');
                                 removeBtn.className = 'article-btn remove-btn';
-                                removeBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>';
+                                removeBtn.innerHTML = trashIconMarkup;
                                 removeBtn.title = 'Remove article';
+                                removeBtn.setAttribute('aria-label', 'Remove article');
                                 removeBtn.type = 'button';
                                 removeBtn.setAttribute('data-url', cleanUrl);
 


### PR DESCRIPTION
## Summary
- add a reusable trash can SVG icon in the static asset bundle
- swap the URL removal button markup to render the trash can symbol instead of the X glyph
- ensure the button keeps its hover styling and accessible labelling when using the new icon
- adjust the trash can SVG proportions with thicker strokes for better visibility

## Testing
- uv run python3 serve.py --port 5001

------
https://chatgpt.com/codex/tasks/task_e_68ee3f18e0e08332bc5f6e633ef97c09