### PR TITLE
Add cache-control headers to blob interactions

### DIFF
--- a/blob_cache.py
+++ b/blob_cache.py
@@ -126,7 +126,11 @@ def _try_read_cache(
         resp = requests.get(
             blob_url,
             timeout=10,
-            headers={"User-Agent": "Mozilla/5.0 (compatible; TLDR-Newsletter/1.0)"},
+            headers={
+                "User-Agent": "Mozilla/5.0 (compatible; TLDR-Newsletter/1.0)",
+                "Cache-Control": "no-cache",
+                "Pragma": "no-cache",
+            },
         )
         resp.raise_for_status()
         util.log(f"[{fn_name}] ✔ Cache hit: {pathname}", logger=logger)
@@ -163,7 +167,11 @@ def _try_read_cache_json(
         resp = requests.get(
             blob_url,
             timeout=10,
-            headers={"User-Agent": "Mozilla/5.0 (compatible; TLDR-Newsletter/1.0)"},
+            headers={
+                "User-Agent": "Mozilla/5.0 (compatible; TLDR-Newsletter/1.0)",
+                "Cache-Control": "no-cache",
+                "Pragma": "no-cache",
+            },
         )
         resp.raise_for_status()
         util.log(f"[{fn_name}] ✔ Cache hit: {pathname}", logger=logger)

--- a/blob_store.py
+++ b/blob_store.py
@@ -89,6 +89,8 @@ def put_file(pathname: str, content: str) -> str:
         headers = {
             "Authorization": f"Bearer {token}",
             "x-add-random-suffix": "0",
+            "x-content-type": "application/json",
+            "x-cache-control-max-age": "60",
         }
 
         response = requests.put(
@@ -220,7 +222,15 @@ def check_file_exists(pathname: str) -> bool:
         import requests
 
         blob_url = f"{base_url}/{pathname}"
-        response = requests.head(blob_url, timeout=10)
+        response = requests.head(
+            blob_url,
+            timeout=10,
+            headers={
+                "User-Agent": "Mozilla/5.0 (compatible; TLDR-Newsletter/1.0)",
+                "Cache-Control": "no-cache",
+                "Pragma": "no-cache",
+            },
+        )
         return response.status_code == 200
 
     except Exception:

--- a/cache_mode.py
+++ b/cache_mode.py
@@ -71,7 +71,9 @@ def get_cache_mode() -> CacheMode:
                     blob_url,
                     timeout=10,
                     headers={
-                        "User-Agent": "Mozilla/5.0 (compatible; TLDR-Newsletter/1.0)"
+                        "User-Agent": "Mozilla/5.0 (compatible; TLDR-Newsletter/1.0)",
+                        "Cache-Control": "no-cache",
+                        "Pragma": "no-cache",
                     },
                 )
                 resp.raise_for_status()

--- a/removed_urls.py
+++ b/removed_urls.py
@@ -26,9 +26,19 @@ def get_removed_urls() -> Set[str]:
         resp = requests.get(
             blob_url,
             timeout=10,
-            headers={"User-Agent": "Mozilla/5.0 (compatible; TLDR-Newsletter/1.0)"},
+            headers={
+                "User-Agent": "Mozilla/5.0 (compatible; TLDR-Newsletter/1.0)",
+                "Cache-Control": "no-cache",
+                "Pragma": "no-cache",
+            },
         )
         resp.raise_for_status()
+        util.log(
+            f"[removed_urls.get_removed_urls] "
+            f"x-vercel-cache={resp.headers.get('x-vercel-cache')} "
+            f"age={resp.headers.get('age')} etag={resp.headers.get('etag')}",
+            logger=logger,
+        )
         util.log(
             f"[removed_urls.get_removed_urls] Cache HIT pathname={REMOVED_URLS_PATHNAME}",
             logger=logger,

--- a/tldr_app.py
+++ b/tldr_app.py
@@ -212,7 +212,15 @@ def invalidate_cache_for_date(date_text: Optional[str]) -> dict:
 
     try:
         blob_url = f"{blob_base_url}/{day_cache_pathname}"
-        response = requests.get(blob_url, timeout=10)
+        response = requests.get(
+            blob_url,
+            timeout=10,
+            headers={
+                "User-Agent": "Mozilla/5.0 (compatible; TLDR-Newsletter/1.0)",
+                "Cache-Control": "no-cache",
+                "Pragma": "no-cache",
+            },
+        )
         response.raise_for_status()
         cached_day = response.json()
         articles = cached_day.get("articles", [])


### PR DESCRIPTION
## Summary
- add cache-control and pragma headers to blob read paths to avoid cached responses
- log vercel cache metadata when retrieving removed URLs
- set blob upload headers to declare content type and cache-control hints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee467fd4d08332be1f219e5b56e3d9