### PR TITLE
Add cursor-agent installation to setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -174,7 +174,7 @@ function main() {
         eval export "$line"
       done
   fi
-  local env_vars="$(env | egrep '(OPENAI|GITHUB|BLOB|TLDR)' | sort -u)"
+  local env_vars="$(env | egrep '(CURSOR|OPENAI|GITHUB|BLOB|TLDR)' | sort -u)"
   local -a env_var_names=(
     'BLOB_READ_WRITE_TOKEN'
     'BLOB_STORE_BASE_URL'


### PR DESCRIPTION
## Summary
- ensure $HOME/.local/bin is available on PATH before installing tools
- install and verify cursor-agent within setup alongside existing dependencies
- require CURSOR_API_KEY and document non-interactive cursor-agent usage guidance

## Testing
- bash -n setup.sh

------
https://chatgpt.com/codex/tasks/task_e_68eeb03347888332a552f4c48c2cde52