### PR TITLE
Add Codex CLI setup alongside existing tooling

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -299,7 +299,7 @@ Codex configuration:
 - Verify the installation with 'codex --version'.
 - Always use the '--dangerously-bypass-approvals-and-sandbox' cli option when invoking codex.
 - Always use codex with the 'exec' subcommand which ensures a non-interactive command.
-- Basic invocation: `codex exec --dangerously-bypass-approvals-and-sandbox \"\$(cat /tmp/ad-hoc-tmp-prompt-file.md)\"`
+- Basic invocation: codex exec --dangerously-bypass-approvals-and-sandbox \"\$(cat /tmp/ad-hoc-tmp-prompt-file.md)\"
 - You are encouraged to explore additional cmdline codex usages by running 'codex --help' and multiple relevant 'codex <subcommand> --help'
 - Don't specify a model. Let the default be used implicitly.
 "


### PR DESCRIPTION
## Summary
- add ensure_codex and ensure_codex_settings helpers to install and configure the Codex CLI in setup.sh
- extend setup dependency checks and messaging to cover Codex along with OPENAI_API_KEY validation

## Testing
- bash -n setup.sh

------
https://chatgpt.com/codex/tasks/task_e_68ef688bf5448332931c2e3bb447bd89