### PR TITLE
Reduce vertical padding for removed article cards

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -378,6 +378,7 @@
             background: #f8f8f8;
             opacity: 0.7;
             border-color: #d0d0d0;
+            padding: 10px 16px;
         }
         
         .article-card.removed:hover {


### PR DESCRIPTION
## Summary
- decrease the vertical padding on removed article cards so they take up less height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68effcfd07a48332925f46337cb93518