### PR TITLE
Sync remove button UI with backend behavior

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1483,6 +1483,75 @@
             });
         }
 
+        function parseTitleWithDomain(titleWithDomain) {
+            if (typeof titleWithDomain !== 'string') {
+                return { title: '', domain: '' };
+            }
+
+            const match = titleWithDomain.match(/\s*\(([^()]*)\)\s*$/);
+            if (!match) {
+                return { title: titleWithDomain.trim(), domain: '' };
+            }
+
+            const domain = match[1].trim();
+            const title = titleWithDomain
+                .slice(0, titleWithDomain.length - match[0].length)
+                .trim();
+            return { title, domain };
+        }
+
+        function getDomainLabelFromUrl(url) {
+            if (typeof url !== 'string' || !url) {
+                return '';
+            }
+
+            try {
+                const parsed = new URL(url);
+                let hostname = (parsed.hostname || '').toLowerCase();
+                if (hostname.startsWith('www.')) {
+                    hostname = hostname.slice(4);
+                }
+
+                const parts = hostname.split('.');
+                if (parts.length >= 2) {
+                    const main = parts[parts.length - 2];
+                    if (main) {
+                        return main.charAt(0).toUpperCase() + main.slice(1);
+                    }
+                } else if (hostname) {
+                    return hostname.charAt(0).toUpperCase() + hostname.slice(1);
+                }
+            } catch (err) {
+                return '';
+            }
+
+            return '';
+        }
+
+        function buildRemovedTitle(card) {
+            if (!card) return '';
+
+            const originalTitle = (card.getAttribute('data-original-title') || '').trim();
+            const domainLabel =
+                (card.getAttribute('data-domain-label') || '').trim() ||
+                getDomainLabelFromUrl(card.getAttribute('data-url') || '');
+
+            let title = originalTitle.replace(/\s*\(\d+\s+minutes?\s+read\)/i, '').trim();
+            if (!title) {
+                title = originalTitle;
+            }
+
+            if (title.length > 10) {
+                title = `${title.slice(0, 10)}...`;
+            }
+
+            if (domainLabel) {
+                return `${title} (${domainLabel})`;
+            }
+
+            return title;
+        }
+
         function markArticleAsRead(card) {
             if (card.classList.contains('removed')) return;
             card.classList.remove('unread');
@@ -1494,6 +1563,53 @@
         function markArticleAsRemoved(card) {
             card.classList.remove('unread', 'read');
             card.classList.add('removed');
+
+            const link = card.querySelector('.article-link');
+            const removedTitle = buildRemovedTitle(card);
+            if (link && removedTitle) {
+                link.textContent = removedTitle;
+                card.setAttribute('data-title', removedTitle);
+            }
+
+            const summary = card.querySelector('.inline-summary');
+            if (summary) {
+                summary.remove();
+            }
+            toggleCopyButton(card, false);
+            card.removeAttribute('data-summary');
+
+            const summaryBtn = card.querySelector('.expand-btn');
+            if (summaryBtn) {
+                const hasLoadedSummary = summaryBtn.classList.contains('loaded');
+                summaryBtn.innerHTML = hasLoadedSummary ? 'Available' : 'Summarize';
+                summaryBtn.title = hasLoadedSummary
+                    ? 'Summary cached - click to show'
+                    : 'Show summary with default reasoning effort';
+                summaryBtn.classList.remove('expanded');
+                if (!hasLoadedSummary) {
+                    summaryBtn.classList.add('collapsed-state');
+                }
+            }
+
+            const tldr = card.querySelector('.inline-tldr');
+            if (tldr) {
+                tldr.remove();
+            }
+            card.removeAttribute('data-tldr');
+
+            const tldrBtn = card.querySelector('.tldr-btn');
+            if (tldrBtn) {
+                const hasLoadedTldr = tldrBtn.classList.contains('loaded');
+                tldrBtn.innerHTML = hasLoadedTldr ? 'Available' : 'TLDR';
+                tldrBtn.title = hasLoadedTldr
+                    ? 'TLDR cached - click to show'
+                    : 'Show TLDR';
+                tldrBtn.classList.remove('expanded');
+                if (!hasLoadedTldr) {
+                    tldrBtn.classList.add('collapsed-state');
+                }
+            }
+
             const articleList = card.closest('.article-list');
             if (articleList) sortArticlesByState(articleList);
         }
@@ -2300,6 +2416,13 @@
                                 const cleanUrl = urlValue.replace('?data-removed=true', '');
 
                                 const articleMeta = urlMetaMap.get(cleanUrl);
+                                const titleParts = parseTitleWithDomain(titleText);
+                                const originalTitle = (articleMeta && articleMeta.title) || titleParts.title || titleText;
+                                card.setAttribute('data-original-title', originalTitle);
+                                const domainLabel = titleParts.domain || getDomainLabelFromUrl(cleanUrl);
+                                if (domainLabel) {
+                                    card.setAttribute('data-domain-label', domainLabel);
+                                }
                                 let sectionKey = null;
                                 if (articleMeta && articleMeta.section_title) {
                                     const sectionOrder = articleMeta.section_order ?? '';


### PR DESCRIPTION
## Summary
- parse article titles to capture original text and friendly domain labels for each card
- reuse backend truncation logic when marking an article as removed and collapse any inline summary or TLDR content
- ensure removal flow updates stored metadata so downstream features stay in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f003fd33b4833298bf4f7b82baf5c0