### PR TITLE
Refactor blob pathname helpers to reuse shared logic

### DIFF
--- a/summarizer.py
+++ b/summarizer.py
@@ -59,20 +59,12 @@ def normalize_summary_effort(value: str) -> str:
 
 def summary_blob_pathname(url: str, *args, **kwargs) -> str:
     """Generate blob pathname for URL summary."""
-    base_path = blob_store.normalize_url_to_pathname(url)
-    base = base_path[:-3] if base_path.endswith(".md") else base_path
-    summary_effort = normalize_summary_effort(kwargs.get("summary_effort", "low"))
-    suffix = "" if summary_effort == "low" else f"-{summary_effort}"
-    return f"{base}-summary{suffix}.md"
+    return _url_summary_pathname(url, *args, **kwargs)
 
 
 def tldr_blob_pathname(url: str, *args, **kwargs) -> str:
     """Generate blob pathname for URL TLDR."""
-    base_path = blob_store.normalize_url_to_pathname(url)
-    base = base_path[:-3] if base_path.endswith(".md") else base_path
-    summary_effort = normalize_summary_effort(kwargs.get("summary_effort", "low"))
-    suffix = "" if summary_effort == "low" else f"-{summary_effort}"
-    return f"{base}-tldr{suffix}.md"
+    return _url_tldr_pathname(url, *args, **kwargs)
 
 
 def _is_github_repo_url(url: str) -> bool:


### PR DESCRIPTION
## Summary
- reuse the internal URL summary helper when generating public summary blob pathnames
- reuse the internal URL TLDR helper to keep blob pathname computation consistent

## Testing
- OPENAI_API_TOKEN="$OPENAI_API_KEY" bash scripts/cli_sanity_check.sh 2>&1 | stdbuf -oL cut -c1-4000

------
https://chatgpt.com/codex/tasks/task_e_68f0e36330508332ab92bea106cd1783