### PR TITLE
Normalize OpenAI env var name usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,12 @@ env | grep -e BLOB -e TLDR -e TOKEN -e API
 
 Rules:
 
-- **Local (Cursor background agents developing the app):** Env vars are prefixed with `TLDR_SCRAPER_` (except `OPENAI_API_TOKEN`, and `GITHUB_API_TOKEN`).
+- **Local (Cursor background agents developing the app):** Env vars are prefixed with `TLDR_SCRAPER_` (except `OPENAI_API_KEY`, and `GITHUB_API_TOKEN`).
 - **Production:** Exactly the same variables but without the `TLDR_SCRAPER_` prefix.
 
 Expected variables (shown here with their base names; prefix with `TLDR_SCRAPER_` locally):
 
-- `OPENAI_API_TOKEN`: `sk-...` (unprefixed in all environments)
+- `OPENAI_API_KEY`: `sk-...` (unprefixed in all environments)
 - `GITHUB_API_TOKEN`: `github_pat_...` (unprefixed in all environments)
 - `BLOB_STORE_BASE_URL`: read URL. Use e.g. `<BLOB_STORE_BASE_URL>/<pathname>`
 - `BLOB_READ_WRITE_TOKEN`: `vercel_blob_rw_...`

--- a/summarizer.py
+++ b/summarizer.py
@@ -440,9 +440,9 @@ def _insert_markdown_into_template(template: str, markdown: str) -> str:
 
 def _call_llm(prompt: str, summary_effort: str = "low") -> str:
     """Call OpenAI API with prompt."""
-    api_key = util.resolve_env_var("OPENAI_API_TOKEN", "")
+    api_key = util.resolve_env_var("OPENAI_API_KEY", "")
     if not api_key:
-        raise RuntimeError("OPENAI_API_TOKEN not set")
+        raise RuntimeError("OPENAI_API_KEY not set")
     if not prompt.strip():
         raise ValueError("Prompt is empty")
 


### PR DESCRIPTION
## Summary
- update the agents guide to document the OPENAI_API_KEY variable name
- switch the summarizer OpenAI client to resolve the OPENAI_API_KEY environment variable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0e879e054833292215840e3584fc2