### PR TITLE
Align CLI sanity truncation helpers with main

### DIFF
--- a/scripts/cli_sanity_check.sh
+++ b/scripts/cli_sanity_check.sh
@@ -47,13 +47,12 @@ TRUNCATE_LIMIT=1000
 truncate_json_output() {
     local json_input="$1"
     printf '%s' "$json_input" | jq -r --argjson limit "$TRUNCATE_LIMIT" '
-        tojson
-        | if length > $limit then .[:$limit] + "...[truncated]" else . end
+        tojson | if length > $limit then .[:$limit] + "...[truncated]" else . end
     '
 }
 
 truncate_text_output() {
-    printf '%s' "$1" | jq -R -r --argjson limit "$TRUNCATE_LIMIT" '
+    printf '%s' "$1" | jq -Rr --argjson limit "$TRUNCATE_LIMIT" '
         if length == 0 then empty
         elif length > $limit then .[:$limit] + "...[truncated]"
         else .


### PR DESCRIPTION
## Summary
- realign the CLI sanity check JSON truncation helper with the main-branch `tojson` approach
- keep text truncation operating in raw line mode instead of slurping the full output

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f20da989ec833284ed25100b481a73