### PR TITLE
Add lazy-loaded favicons to article links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -491,6 +491,7 @@
             display: inline-block;
             vertical-align: -0.125em;
             object-fit: contain;
+            margin-right: 1ch;
         }
 
         .article-link:hover {


### PR DESCRIPTION
## Summary
- add lazy-loaded favicons to article links and wrap their text in a dedicated span
- ensure article title updates go through a helper so favicon markup persists
- adjust styles so links accommodate the favicon while keeping baseline alignment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f24ee72f2c8332b78b49e6cdc579d4