### PR TITLE
Fix client debug log string to prevent syntax error

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2984,8 +2984,7 @@
                                     summary.textContent = 'Debug logs';
                                     const pre = document.createElement('pre');
                                     pre.style.whiteSpace = 'pre-wrap';
-                                    pre.textContent = data.stats.debug_logs.map(l => String(l)).join('
-');
+                                    pre.textContent = data.stats.debug_logs.map(l => String(l)).join('\n');
                                     details.appendChild(summary);
                                     details.appendChild(pre);
                                     slot.appendChild(details);


### PR DESCRIPTION
## Summary
- escape the debug log join string so the inline script parses successfully on load

## Testing
- node --check tmp_script.js

------
https://chatgpt.com/codex/tasks/task_e_68f9fca463a48332a274c58337ea8b16