### PR TITLE
Introduce Article Lifecycle reducer (Domain A state machine)

### DIFF
--- a/client/src/hooks/useArticleState.js
+++ b/client/src/hooks/useArticleState.js
@@ -1,5 +1,10 @@
 import { getNewsletterScrapeKey } from '../lib/storageKeys'
-import { ArticleLifecycleEventType, deriveArticleLifecycleState, reduceArticleLifecycle } from '../reducers/articleLifecycleReducer'
+import {
+  ArticleLifecycleEventType,
+  ArticleLifecycleState,
+  deriveArticleLifecycleState,
+  reduceArticleLifecycle
+} from '../reducers/articleLifecycleReducer'
 import { useSupabaseStorage } from './useSupabaseStorage'
 
 export function useArticleState(date, url) {
@@ -9,8 +14,8 @@ export function useArticleState(date, url) {
   const article = payload?.articles?.find(a => a.url === url) || null
 
   const lifecycleState = deriveArticleLifecycleState(article)
-  const isRead = lifecycleState === 'read'
-  const isRemoved = lifecycleState === 'removed'
+  const isRead = lifecycleState === ArticleLifecycleState.READ
+  const isRemoved = lifecycleState === ArticleLifecycleState.REMOVED
 
   const updateArticle = (updater) => {
     if (!article) return
@@ -28,7 +33,7 @@ export function useArticleState(date, url) {
   }
 
   const updateLifecycle = (event) => {
-    updateArticle(current => reduceArticleLifecycle(current, event))
+    updateArticle(current => reduceArticleLifecycle(current, event).patch)
   }
 
   const markAsRead = () => {
@@ -52,7 +57,11 @@ export function useArticleState(date, url) {
   }
 
   const toggleRemove = () => {
-    updateLifecycle({ type: ArticleLifecycleEventType.REMOVED_TOGGLED })
+    updateLifecycle({
+      type: isRemoved
+        ? ArticleLifecycleEventType.REMOVED_RESTORED
+        : ArticleLifecycleEventType.REMOVED_MARKED
+    })
   }
 
   return {

--- a/client/src/reducers/articleLifecycleReducer.js
+++ b/client/src/reducers/articleLifecycleReducer.js
@@ -1,0 +1,36 @@
+export const ArticleLifecycleEventType = Object.freeze({
+  READ_MARKED: 'READ_MARKED',
+  READ_CLEARED: 'READ_CLEARED',
+  REMOVED_MARKED: 'REMOVED_MARKED',
+  REMOVED_TOGGLED: 'REMOVED_TOGGLED',
+})
+
+export function deriveArticleLifecycleState(article) {
+  if (!article) return 'unread'
+  if (article.removed) return 'removed'
+  if (article.read?.isRead) return 'read'
+  return 'unread'
+}
+
+export function reduceArticleLifecycle(article, event) {
+  switch (event.type) {
+    case ArticleLifecycleEventType.READ_MARKED:
+      return {
+        read: { isRead: true, markedAt: event.markedAt },
+      }
+    case ArticleLifecycleEventType.READ_CLEARED:
+      return {
+        read: { isRead: false, markedAt: null },
+      }
+    case ArticleLifecycleEventType.REMOVED_MARKED:
+      return {
+        removed: true,
+      }
+    case ArticleLifecycleEventType.REMOVED_TOGGLED:
+      return {
+        removed: !article.removed,
+      }
+    default:
+      throw new Error(`Unknown article lifecycle event: ${event.type}`)
+  }
+}


### PR DESCRIPTION
### Motivation
- Centralize and formalize the durable Article lifecycle (Domain A) state (read / removed) as a small state machine so transitions are explicit and easier to coordinate with the reducer-pattern migration described in `thoughts/26-01-30-migrate-to-reducer-pattern`.
- Prepare the client code for safer orchestrations between transient UI domains (summary view, gestures) and durable article state by expressing lifecycle changes as events rather than ad-hoc inline mutations.

### Description
- Added a new reducer module `client/src/reducers/articleLifecycleReducer.js` that exports `ArticleLifecycleEventType`, `deriveArticleLifecycleState`, and `reduceArticleLifecycle` to model `unread | read | removed` and the canonical lifecycle events (`READ_MARKED`, `READ_CLEARED`, `REMOVED_MARKED`, `REMOVED_TOGGLED`).
- Updated `client/src/hooks/useArticleState.js` to derive `isRead` / `isRemoved` via `deriveArticleLifecycleState(article)` and to mutate article lifecycle through `updateLifecycle(event)` which applies `reduceArticleLifecycle` and saves via the existing `useSupabaseStorage` plumbing (preserves the existing storage contract and optimistic update behavior).
- Kept the public `useArticleState` API stable (returns `article`, `isRead`, `isRemoved`, `markAsRead`, `markAsUnread`, `toggleRead`, `markAsRemoved`, `toggleRemove`, `updateArticle`) so components continue to work while lifecycle logic is now event-driven.

### Testing
- No automated tests were run for this change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697fc8dc847083228a0b6c1938ab2aaa)