### PR TITLE
Implement Article lifecycle (Domain A) reducer

### DIFF
--- a/client/src/hooks/useArticleState.js
+++ b/client/src/hooks/useArticleState.js
@@ -39,7 +39,10 @@ export function useArticleState(date, url) {
   }
 
   const markAsRead = () => {
-    dispatchLifecycleEvent({ type: ArticleLifecycleEventType.MARK_READ })
+    dispatchLifecycleEvent({
+      type: ArticleLifecycleEventType.MARK_READ,
+      markedAt: new Date().toISOString()
+    })
   }
 
   const markAsUnread = () => {
@@ -47,7 +50,10 @@ export function useArticleState(date, url) {
   }
 
   const toggleRead = () => {
-    dispatchLifecycleEvent({ type: ArticleLifecycleEventType.TOGGLE_READ })
+    dispatchLifecycleEvent({
+      type: ArticleLifecycleEventType.TOGGLE_READ,
+      markedAt: new Date().toISOString()
+    })
   }
 
   const markAsRemoved = () => {

--- a/client/src/reducers/articleLifecycleReducer.js
+++ b/client/src/reducers/articleLifecycleReducer.js
@@ -1,0 +1,74 @@
+export const ArticleLifecycleState = Object.freeze({
+  UNREAD: 'unread',
+  READ: 'read',
+  REMOVED: 'removed',
+})
+
+export const ArticleLifecycleEventType = Object.freeze({
+  MARK_READ: 'MARK_READ',
+  MARK_UNREAD: 'MARK_UNREAD',
+  TOGGLE_READ: 'TOGGLE_READ',
+  MARK_REMOVED: 'MARK_REMOVED',
+  TOGGLE_REMOVED: 'TOGGLE_REMOVED',
+  RESTORE: 'RESTORE',
+})
+
+function buildReadPatch(isRead) {
+  return {
+    read: {
+      isRead,
+      markedAt: isRead ? new Date().toISOString() : null,
+    },
+  }
+}
+
+export function getArticleLifecycleState(article) {
+  if (article?.removed) return ArticleLifecycleState.REMOVED
+  if (article?.read?.isRead) return ArticleLifecycleState.READ
+  return ArticleLifecycleState.UNREAD
+}
+
+export function reduceArticleLifecycle(article, event) {
+  const currentState = getArticleLifecycleState(article)
+  const isRead = Boolean(article?.read?.isRead)
+  const isRemoved = Boolean(article?.removed)
+
+  switch (event.type) {
+    case ArticleLifecycleEventType.MARK_READ:
+      return {
+        state: isRemoved ? ArticleLifecycleState.REMOVED : ArticleLifecycleState.READ,
+        patch: buildReadPatch(true),
+      }
+    case ArticleLifecycleEventType.MARK_UNREAD:
+      return {
+        state: isRemoved ? ArticleLifecycleState.REMOVED : ArticleLifecycleState.UNREAD,
+        patch: buildReadPatch(false),
+      }
+    case ArticleLifecycleEventType.TOGGLE_READ:
+      return isRead
+        ? {
+            state: isRemoved ? ArticleLifecycleState.REMOVED : ArticleLifecycleState.UNREAD,
+            patch: buildReadPatch(false),
+          }
+        : {
+            state: isRemoved ? ArticleLifecycleState.REMOVED : ArticleLifecycleState.READ,
+            patch: buildReadPatch(true),
+          }
+    case ArticleLifecycleEventType.MARK_REMOVED:
+      return { state: ArticleLifecycleState.REMOVED, patch: { removed: true } }
+    case ArticleLifecycleEventType.TOGGLE_REMOVED:
+      return isRemoved
+        ? {
+            state: isRead ? ArticleLifecycleState.READ : ArticleLifecycleState.UNREAD,
+            patch: { removed: false },
+          }
+        : { state: ArticleLifecycleState.REMOVED, patch: { removed: true } }
+    case ArticleLifecycleEventType.RESTORE:
+      return {
+        state: isRead ? ArticleLifecycleState.READ : ArticleLifecycleState.UNREAD,
+        patch: { removed: false },
+      }
+    default:
+      return { state: currentState, patch: null }
+  }
+}


### PR DESCRIPTION
### Motivation
- Implement the Domain A state machine for article lifecycle (read / unread / removed) following the reducer/finite-state guidance in `thoughts/26-01-30-migrate-to-reducer-pattern` so lifecycle logic is a single source of truth. 
- Provide a closed, testable reducer that other domains can coordinate with via events rather than scattering lifecycle guards across hooks and components.

### Description
- Add `client/src/reducers/articleLifecycleReducer.js` which defines `ArticleLifecycleState`, `ArticleLifecycleEventType`, `getArticleLifecycleState`, and `reduceArticleLifecycle` returning canonical state and storage patch objects. 
- Route existing article lifecycle operations through the reducer by updating `client/src/hooks/useArticleState.js` to dispatch lifecycle events (`MARK_READ`, `TOGGLE_REMOVED`, etc.) via the reducer and apply the returned patch with the existing `updateArticle` mechanism. 
- Expose the computed `lifecycleState` from `useArticleState` so consumers can observe the high-level lifecycle (`unread` / `read` / `removed`) without duplicating logic.

### Testing
- No automated tests were executed for this change because the client package has no test script configured and no test run was requested; therefore no test results are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697fc9e32a1c83229aad8dd872cea3d9)