### PR TITLE
Implement summary view reducer for Domain C

### DIFF
--- a/client/src/reducers/summaryViewReducer.js
+++ b/client/src/reducers/summaryViewReducer.js
@@ -1,0 +1,44 @@
+export const SummaryViewMode = Object.freeze({
+  COLLAPSED: 'collapsed',
+  EXPANDED: 'expanded',
+})
+
+export const SummaryViewEventType = Object.freeze({
+  OPEN_REQUESTED: 'OPEN_REQUESTED',
+  CLOSE_REQUESTED: 'CLOSE_REQUESTED',
+})
+
+/**
+ * @example
+ * reduceSummaryView(
+ *   { mode: SummaryViewMode.COLLAPSED, expandedBy: null },
+ *   { type: SummaryViewEventType.OPEN_REQUESTED, reason: 'tap' }
+ * ).state.mode
+ * //=> 'expanded'
+ */
+export function reduceSummaryView(state, event) {
+  switch (event.type) {
+    case SummaryViewEventType.OPEN_REQUESTED:
+      if (state.mode === SummaryViewMode.EXPANDED) {
+        return { state }
+      }
+      return {
+        state: {
+          mode: SummaryViewMode.EXPANDED,
+          expandedBy: event.reason || null,
+        },
+      }
+    case SummaryViewEventType.CLOSE_REQUESTED:
+      if (state.mode === SummaryViewMode.COLLAPSED) {
+        return { state }
+      }
+      return {
+        state: {
+          mode: SummaryViewMode.COLLAPSED,
+          expandedBy: null,
+        },
+      }
+    default:
+      return { state }
+  }
+}


### PR DESCRIPTION
### Motivation
- Centralize and formalize the summary view (`collapsed` ↔ `expanded`) handling using the reducer pattern to match Domain A's migration and reduce implicit coupling.
- Keep view transitions pure and testable while preserving existing side-effectful behavior (lock acquisition and summary fetch) in the hook runtime.
- Avoid over-engineering coordination with Domain B for now by keeping the reducer closed and low-ceremony.

### Description
- Add `client/src/reducers/summaryViewReducer.js` which exports `SummaryViewMode`, `SummaryViewEventType`, and the pure `reduceSummaryView` reducer. 
- Update `client/src/hooks/useSummary.js` to replace the ad-hoc `expanded` boolean with `summaryViewState` driven by the reducer and to introduce `dispatchSummaryViewEvent` which logs transitions and drives open/close behavior via `SummaryViewEventType` while retaining `acquireZenLock` semantics and the existing fetch flow. 
- Preserve summary data flow and lock semantics so a successful fetch still auto-expands when the lock is acquired, and user taps route through reducer events that the hook interprets. 
- Document the implementation, rationale, and decisions in `thoughts/26-01-30-migrate-to-reducer-pattern/implementation-domain-c.md` and keep the reducer intentionally closed to avoid cross-domain reads or direct side effects. 

### Testing
- No automated tests were executed for this change. 
- `./setup.sh` was run earlier in the session and completed, but running the repository hooks attempted to create a virtualenv and failed due to a network error downloading `propcache` (PyPI), so CI/build steps were not executed in this session. 
- Functional behavior was implemented to preserve existing runtime flows (no API surface changes), and the code changes are confined to the client-side reducer and hook integration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698220b172c88322ad7740814c56d4be)