### PR TITLE
Add gesture reducer for swipe interactions

### DIFF
--- a/client/src/reducers/gestureReducer.js
+++ b/client/src/reducers/gestureReducer.js
@@ -1,0 +1,64 @@
+export const GestureMode = Object.freeze({
+  IDLE: 'idle',
+  DRAGGING: 'dragging',
+})
+
+export const GestureEventType = Object.freeze({
+  DRAG_START: 'DRAG_START',
+  DRAG_END: 'DRAG_END',
+  DRAG_ERROR: 'DRAG_ERROR',
+  CLEAR_ERROR: 'CLEAR_ERROR',
+})
+
+export function createInitialGestureState() {
+  return {
+    mode: GestureMode.IDLE,
+    errorMessage: null,
+  }
+}
+
+export function reduceGesture(state, event) {
+  switch (event.type) {
+    case GestureEventType.DRAG_START:
+      return {
+        state: {
+          ...state,
+          mode: GestureMode.DRAGGING,
+          errorMessage: null,
+        },
+        decision: null,
+      }
+    case GestureEventType.DRAG_END: {
+      const swipeThreshold = -100
+      const velocityThreshold = -300
+      const shouldComplete = event.offsetX < swipeThreshold || event.velocityX < velocityThreshold
+      return {
+        state: {
+          ...state,
+          mode: GestureMode.IDLE,
+          errorMessage: null,
+        },
+        decision: { shouldComplete },
+      }
+    }
+    case GestureEventType.DRAG_ERROR:
+      return {
+        state: {
+          ...state,
+          mode: GestureMode.IDLE,
+          errorMessage: event.message,
+        },
+        decision: null,
+      }
+    case GestureEventType.CLEAR_ERROR:
+      return {
+        state: {
+          ...state,
+          errorMessage: null,
+        },
+        decision: null,
+      }
+    default:
+      return { state, decision: null }
+  }
+}

--- a/thoughts/26-01-30-migrate-to-reducer-pattern/implementation-domain-d-execution.md
+++ b/thoughts/26-01-30-migrate-to-reducer-pattern/implementation-domain-d-execution.md
@@ -1,0 +1,17 @@
+# Implementation: Domain D - Gesture reducer migration
+
+## Scope
+Refactor swipe-to-remove gesture handling into a closed reducer and keep select-mode logic in the Interaction domain.
+
+## Decisions (for)
+- Added a dedicated gesture reducer to own `idle`/`dragging` transitions and drag error state, matching the reducer pattern used in other domains.
+- Centralized swipe completion decisions in the reducer so the hook only executes effects (animations, removal callbacks).
+- Kept gesture logging tied to reducer transitions to make state changes explicit.
+
+## Decisions (against)
+- Did not add a pointer session model or tap-vs-drag promotion threshold because Framer Motion already gates `onDragStart` and the current UX does not depend on low-level pointer tracking.
+- Did not merge select-mode into the gesture reducer because selection state is already owned globally by `InteractionContext`, and duplicating that state would increase coupling.
+- Avoided adding new cross-domain mediator logic; the reducer emits a single decision used locally by the hook.
+
+## Result
+Gesture behavior now has a closed, testable reducer while keeping the existing interaction and selection architecture intact.


### PR DESCRIPTION
### Motivation
- Move Domain D (gesture/interaction) to a closed reducer pattern to make swipe-to-remove logic explicit and testable. 
- Centralize swipe completion decisioning and transition logging to match the reducer approach used for other domains.

### Description
- Add a new reducer `client/src/reducers/gestureReducer.js` that models `idle`/`dragging` modes and exposes `GestureEventType`, `GestureMode`, `createInitialGestureState`, and `reduceGesture`.
- Refactor `client/src/hooks/useSwipeToRemove.js` to drive gesture state via the reducer, dispatch `DRAG_START` / `DRAG_END` / `DRAG_ERROR` / `CLEAR_ERROR` events, and log transitions with `logTransition` instead of local `useState` bookkeeping.
- Keep swipe completion decision local to the reducer and let the hook execute effects (animations and `onSwipeComplete`) based on the reducer's `decision` return value.
- Add a rationale/implementation note at `thoughts/26-01-30-migrate-to-reducer-pattern/implementation-domain-d-execution.md` describing decisions for and against alternative designs.

### Testing
- Ran `./setup.sh` which completed its documented steps but observed a transient package fetch failure during the `.githooks/post-checkout` virtualenv step where `multidict` failed to download due to a network/tunnel error. 
- No automated unit tests were executed for this change and no client build was performed as part of this PR. 
- Verified repository changes committed successfully with the message `Add gesture reducer for swipe interactions`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698221398aa88322880fa75308efbf3a)