### PR TITLE
Migrate Domain D swipe state to gesture reducer

### DIFF
--- a/client/src/reducers/gestureReducer.js
+++ b/client/src/reducers/gestureReducer.js
@@ -1,0 +1,51 @@
+export const GestureMode = Object.freeze({
+  IDLE: 'idle',
+  DRAGGING: 'dragging',
+})
+
+export const GestureEventType = Object.freeze({
+  DRAG_STARTED: 'DRAG_STARTED',
+  DRAG_FINISHED: 'DRAG_FINISHED',
+  DRAG_FAILED: 'DRAG_FAILED',
+  CLEAR_ERROR: 'CLEAR_ERROR',
+})
+
+export function createInitialGestureState() {
+  return {
+    mode: GestureMode.IDLE,
+    errorMessage: null,
+  }
+}
+
+export function reduceGesture(state, event) {
+  switch (event.type) {
+    case GestureEventType.DRAG_STARTED:
+      return {
+        ...state,
+        mode: GestureMode.DRAGGING,
+        errorMessage: null,
+      }
+
+    case GestureEventType.DRAG_FINISHED:
+      return {
+        ...state,
+        mode: GestureMode.IDLE,
+      }
+
+    case GestureEventType.DRAG_FAILED:
+      return {
+        ...state,
+        mode: GestureMode.IDLE,
+        errorMessage: event.errorMessage,
+      }
+
+    case GestureEventType.CLEAR_ERROR:
+      return {
+        ...state,
+        errorMessage: null,
+      }
+
+    default:
+      return state
+  }
+}

--- a/thoughts/26-01-30-migrate-to-reducer-pattern/implementation-domain-d.md
+++ b/thoughts/26-01-30-migrate-to-reducer-pattern/implementation-domain-d.md
@@ -1,0 +1,20 @@
+# Implementation: Domain D - Gesture Interaction Reducer
+
+## Scope and Judgment Call
+Domain D was modeled as interaction UI state (`idle`, `dragging`, `select-mode`). The existing code already had `select-mode` managed globally in `interactionReducer` via `selectedIds.size > 0`, while gesture drag state remained ad-hoc local state in `useSwipeToRemove`.
+
+The chosen approach was a surgical migration: convert only the local gesture drag state to a closed reducer, and keep select-mode ownership in the existing interaction reducer.
+
+## Decisions For (and why)
+- **Added a dedicated `gestureReducer`** with explicit events (`DRAG_STARTED`, `DRAG_FINISHED`, `DRAG_FAILED`, `CLEAR_ERROR`) to replace ad-hoc `useState` drag/error mutation in `useSwipeToRemove`.
+- **Kept reducer scope local to swipe behavior** so Domain D gains explicit transition modeling without introducing cross-domain orchestration overhead.
+- **Reused existing integration points** (`logTransition`, `onSwipeComplete`, Framer Motion controls) so behavior remains stable while state transitions become declarative.
+
+## Decisions Against (and why)
+- **Did not fold `select-mode` into the new gesture reducer** because it already belongs to `interactionReducer` and is shared app-wide. Moving it would duplicate ownership and increase coupling.
+- **Did not introduce a monolithic Domain D super-reducer** across context + swipe hook. That would add boilerplate and coordination complexity without user-visible value.
+- **Did not change drag thresholds or animation behavior** because the task is architectural migration, not interaction retuning.
+
+## Files Touched
+- `client/src/reducers/gestureReducer.js`
+- `client/src/hooks/useSwipeToRemove.js`


### PR DESCRIPTION
### Motivation
- Make gesture (Domain D) transitions explicit and declarative by replacing ad-hoc local drag state with a closed reducer while avoiding broad re-architecting of selection ownership. 
- Keep scope surgical: only replace the local swipe/drag state, leaving `select-mode` in the global `interactionReducer` to avoid duplicating ownership.
- Improve clarity and future testability of swipe transitions (`idle` ↔ `dragging`) and error handling without changing UX behavior or thresholds.

### Description
- Add `client/src/reducers/gestureReducer.js` implementing `GestureMode` and `GestureEventType` plus `createInitialGestureState` and `reduceGesture` to model gesture transitions. 
- Refactor `client/src/hooks/useSwipeToRemove.js` to use `useReducer(reduceGesture, ...)` instead of `useState` for `isDragging`/`dragError`, and dispatch `DRAG_STARTED`, `DRAG_FINISHED`, `DRAG_FAILED`, and `CLEAR_ERROR` events while preserving `logTransition`, Framer Motion `controls`, and `onSwipeComplete` behavior. 
- Add implementation notes at `thoughts/26-01-30-migrate-to-reducer-pattern/implementation-domain-d.md` documenting scope, rationale, and decisions explicitly deferred to avoid over-engineering.

### Testing
- Ran project setup with `./setup.sh` (completed successfully). 
- Built the frontend with `cd client && npm run build`, which completed successfully (Vite build finished without errors). 
- Verified the app compiles after the change and that swipe integration points (`onSwipeComplete`, animation controls, transition logging) are unchanged by the migration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984ba93f0d48322b1b2205efd00f7e1)