### PR TITLE
Remove stale ephemeral .codex handling from post-checkout hook

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-03-29 11:01
+last_updated: 2026-03-29 12:59
 ---
 # Git Hooks
 
@@ -50,12 +50,6 @@ The Python script is a drop-in replacement for `eza` to avoid installation time.
 Ensures the local clone has the `merge.ours` driver configured so Git respects the `PROJECT_STRUCTURE.md merge=ours` rule from `.gitattributes`.
 
 Also regenerates `PROJECT_STRUCTURE.md` using the Python script to ensure the file is present and up-to-date when switching branches.
-
-`.codex/{agents,skills}` are version-tracked symlinks to `.agents/` and are restored by git automatically on checkout.
-
-### post-merge, post-rewrite
-
-These hooks ensure the local clone always has the `merge.ours` driver configured so Git respects the `PROJECT_STRUCTURE.md merge=ours` rule from `.gitattributes`.
 
 ## GitHub Actions
 

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-01-26 22:00, d514a99
+last_updated: 2026-03-29 11:01
 ---
 # Git Hooks
 
@@ -51,7 +51,7 @@ Ensures the local clone has the `merge.ours` driver configured so Git respects t
 
 Also regenerates `PROJECT_STRUCTURE.md` using the Python script to ensure the file is present and up-to-date when switching branches.
 
-Creates an ephemeral `.codex` directory as a read-only copy of `.claude/skills` (not version-tracked).
+`.codex/{agents,skills}` are version-tracked symlinks to `.agents/` and are restored by git automatically on checkout.
 
 ### post-merge, post-rewrite
 

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -14,12 +14,6 @@ git config --local merge.ours.driver true
 source ./.githooks/util.sh
 generate_project_structure
 
-# Ephemeral .codex directory: a read-only copy of .claude/skills (not version tracked)
-rm -rf .codex 1>/dev/null 2>&1
-mkdir -p .codex
-cp -r .claude/skills .codex/
-chmod -R a-w .codex
-
 # Only run on branch checkouts (not file checkouts)
 if [[ "$3" = "1" && "${#SYNC_PATHS[@]}" -gt 0 ]]; then
   echo "[post-checkout] Syncing external .claude subdirectories..."

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,47 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-# Paths to sync from external .claude repo
-SYNC_PATHS=(
-  # "skills/conversations"
-  # Add more paths here as needed
-)
-
-EXTERNAL_REPO="https://github.com/giladbarnea/.claude.git"
-
 git config --local merge.ours.driver true
 
 source ./.githooks/util.sh
 generate_project_structure
-
-# Only run on branch checkouts (not file checkouts)
-if [[ "$3" = "1" && "${#SYNC_PATHS[@]}" -gt 0 ]]; then
-  echo "[post-checkout] Syncing external .claude subdirectories..."
-
-  TEMP_DIR="/tmp/.claude-external-$$"
-
-  git clone --filter=blob:none --sparse "$EXTERNAL_REPO" "$TEMP_DIR" 2>/dev/null || {
-    echo "[post-checkout] Failed to clone external .claude repo"
-    exit 0
-  }
-
-  cd "$TEMP_DIR" || exit 0
-  git sparse-checkout init --cone
-
-  # Add all paths to sparse checkout
-  for path in "${SYNC_PATHS[@]}"; do
-    git sparse-checkout add "$path"
-  done
-
-  cd - >/dev/null || exit 0
-
-  # Copy all paths
-  for path in "${SYNC_PATHS[@]}"; do
-    mkdir -p ".claude/$(dirname "$path")"
-    cp -r "$TEMP_DIR/$path" ".claude/$path" 2>/dev/null
-    echo "[post-checkout] Synced $path"
-  done
-
-  rm -rf "$TEMP_DIR"
-  echo "[post-checkout] Done syncing external .claude subdirectories"
-fi

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-git config --local merge.ours.driver true

--- a/.githooks/post-rewrite
+++ b/.githooks/post-rewrite
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-git config --local merge.ours.driver true


### PR DESCRIPTION
.codex is now version-tracked (symlinks in git since 1cb8c7f).
The hook was nuking the tracked symlinks on every checkout.

https://claude.ai/code/session_012NSDXE74e28LiwYT9CG7yW