### PR TITLE
useDigest: add guards, persist loading state, ensure cleanup, and add DIGEST docs

### DIFF
--- a/client/src/hooks/useDigest.js
+++ b/client/src/hooks/useDigest.js
@@ -1,6 +1,6 @@
 import DOMPurify from 'dompurify'
 import { marked } from 'marked'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useInteraction } from '../contexts/InteractionContext'
 import { logTransition } from '../lib/stateTransitionLogger'
 import { getNewsletterScrapeKey } from '../lib/storageKeys'
@@ -69,7 +69,12 @@ export function useDigest(results) {
 
   const trigger = async (articleDescriptors) => {
     const payloads = results?.payloads
+    if (!payloads || payloads.length === 0) return
+    if (!articleDescriptors || articleDescriptors.length < 2) return
+
     const date = findMostRecentDate(articleDescriptors, payloads)
+    if (!date) return
+
     setTargetDate(date)
     setTriggering(true)
 
@@ -85,6 +90,12 @@ export function useDigest(results) {
     const articleUrls = articleDescriptors.map(d => d.url)
 
     try {
+      writeDigest({
+        status: summaryDataReducer.SummaryDataStatus.LOADING,
+        effort: 'low',
+        errorMessage: null,
+      })
+
       const response = await window.fetch('/api/digest', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -110,7 +121,6 @@ export function useDigest(results) {
           logTransition('digest', DIGEST_LOCK_OWNER, summaryDataReducer.SummaryDataStatus.LOADING, summaryDataReducer.SummaryDataStatus.AVAILABLE)
           return { ...current, digest: { ...(current.digest || {}), ...successPatch } }
         })
-        setTriggering(false)
         clearSelection()
         expand()
       } else {
@@ -118,21 +128,19 @@ export function useDigest(results) {
           status: summaryDataReducer.SummaryDataStatus.ERROR,
           errorMessage: result.error,
         })
-        setTriggering(false)
       }
-      requestTokenRef.current = null
 
     } catch (error) {
       if (error.name === 'AbortError') {
-        requestTokenRef.current = null
         return
       }
       writeDigest({
         status: summaryDataReducer.SummaryDataStatus.ERROR,
         errorMessage: error.message,
       })
-      setTriggering(false)
+    } finally {
       requestTokenRef.current = null
+      setTriggering(false)
     }
   }
 
@@ -148,6 +156,15 @@ export function useDigest(results) {
     releaseZenLock(DIGEST_LOCK_OWNER)
     setExpanded(false)
   }
+
+  useEffect(() => {
+    return () => {
+      releaseZenLock(DIGEST_LOCK_OWNER)
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort()
+      }
+    }
+  }, [])
 
   return {
     data,

--- a/client/src/hooks/useDigest.js
+++ b/client/src/hooks/useDigest.js
@@ -23,6 +23,7 @@ export function useDigest(results) {
   const [expanded, setExpanded] = useState(false)
   const [targetDate, setTargetDate] = useState(null)
   const [triggering, setTriggering] = useState(false)
+  const [pendingRequest, setPendingRequest] = useState(null)
   const abortControllerRef = useRef(null)
   const requestTokenRef = useRef(null)
 
@@ -67,7 +68,9 @@ export function useDigest(results) {
     })
   }
 
-  const trigger = async (articleDescriptors) => {
+  const createRequestToken = () => `${Date.now()}-${Math.random().toString(16).slice(2)}`
+
+  const trigger = (articleDescriptors) => {
     const payloads = results?.payloads
     if (!payloads || payloads.length === 0) return
     if (!articleDescriptors || articleDescriptors.length < 2) return
@@ -75,74 +78,88 @@ export function useDigest(results) {
     const date = findMostRecentDate(articleDescriptors, payloads)
     if (!date) return
 
-    setTargetDate(date)
-    setTriggering(true)
+    const requestToken = createRequestToken()
+    requestTokenRef.current = requestToken
 
     if (abortControllerRef.current) {
       abortControllerRef.current.abort()
     }
+    setPendingRequest({ articleDescriptors, date, requestToken })
+    setTargetDate(date)
+    setTriggering(true)
+  }
+
+  useEffect(() => {
+    if (!pendingRequest) return
+    if (targetDate !== pendingRequest.date) return
+    if (!payload || payload.date !== pendingRequest.date) return
+
+    const { articleDescriptors, requestToken } = pendingRequest
+    const articleUrls = articleDescriptors.map(d => d.url)
     const controller = new AbortController()
     abortControllerRef.current = controller
+    setPendingRequest(null)
 
-    const requestToken = `${Date.now()}-${Math.random().toString(16).slice(2)}`
-    requestTokenRef.current = requestToken
-
-    const articleUrls = articleDescriptors.map(d => d.url)
-
-    try {
-      writeDigest({
-        status: summaryDataReducer.SummaryDataStatus.LOADING,
-        effort: 'low',
-        errorMessage: null,
-      })
-
-      const response = await window.fetch('/api/digest', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ articles: articleDescriptors, effort: 'low' }),
-        signal: controller.signal,
-      })
-
-      const result = await response.json()
-
-      if (requestTokenRef.current !== requestToken) return
-
-      if (result.success) {
-        const successPatch = {
-          status: summaryDataReducer.SummaryDataStatus.AVAILABLE,
-          markdown: result.digest_markdown,
-          articleUrls: result.included_urls ?? articleUrls,
-          generatedAt: new Date().toISOString(),
+    const runDigest = async () => {
+      try {
+        writeDigest({
+          status: summaryDataReducer.SummaryDataStatus.LOADING,
           effort: 'low',
           errorMessage: null,
-        }
-        setPayloadRef.current(current => {
-          if (!current) return current
-          logTransition('digest', DIGEST_LOCK_OWNER, summaryDataReducer.SummaryDataStatus.LOADING, summaryDataReducer.SummaryDataStatus.AVAILABLE)
-          return { ...current, digest: { ...(current.digest || {}), ...successPatch } }
         })
-        clearSelection()
-        expand()
-      } else {
+
+        const response = await window.fetch('/api/digest', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ articles: articleDescriptors, effort: 'low' }),
+          signal: controller.signal,
+        })
+
+        const result = await response.json()
+
+        if (requestTokenRef.current !== requestToken) return
+
+        if (result.success) {
+          const successPatch = {
+            status: summaryDataReducer.SummaryDataStatus.AVAILABLE,
+            markdown: result.digest_markdown,
+            articleUrls: result.included_urls ?? articleUrls,
+            generatedAt: new Date().toISOString(),
+            effort: 'low',
+            errorMessage: null,
+          }
+          setPayloadRef.current(current => {
+            if (!current) return current
+            logTransition('digest', DIGEST_LOCK_OWNER, summaryDataReducer.SummaryDataStatus.LOADING, summaryDataReducer.SummaryDataStatus.AVAILABLE)
+            return { ...current, digest: { ...(current.digest || {}), ...successPatch } }
+          })
+          clearSelection()
+          expand()
+          return
+        }
+
         writeDigest({
           status: summaryDataReducer.SummaryDataStatus.ERROR,
           errorMessage: result.error,
         })
+      } catch (error) {
+        if (error.name === 'AbortError') {
+          return
+        }
+        writeDigest({
+          status: summaryDataReducer.SummaryDataStatus.ERROR,
+          errorMessage: error.message,
+        })
+      } finally {
+        if (requestTokenRef.current === requestToken) {
+          requestTokenRef.current = null
+          setTriggering(false)
+        }
       }
-
-    } catch (error) {
-      if (error.name === 'AbortError') {
-        return
-      }
-      writeDigest({
-        status: summaryDataReducer.SummaryDataStatus.ERROR,
-        errorMessage: error.message,
-      })
-    } finally {
-      requestTokenRef.current = null
-      setTriggering(false)
     }
-  }
+
+    void runDigest()
+  }, [pendingRequest, payload, targetDate, clearSelection])
 
   const expand = () => {
     if (acquireZenLock(DIGEST_LOCK_OWNER)) {

--- a/docs/DIGEST.md
+++ b/docs/DIGEST.md
@@ -1,0 +1,241 @@
+---
+last_updated: 2026-03-29 17:24
+---
+# Digest Feature Architecture
+
+## Overview
+
+The Digest feature lets a user select multiple feed articles and generate a single synthesized AI digest. It spans client selection state, client overlay/state persistence, backend orchestration, content extraction, Gemini generation, and server-side digest caching.
+
+---
+
+## Architecture Diagram (Space)
+
+> Focus: Structural boundaries and major relationships for the Digest domain.
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│  USER BROWSER                                                           │
+│                                                                         │
+│  ┌───────────────────────────────────────────────────────────────────┐  │
+│  │ React Client                                                      │  │
+│  │                                                                   │  │
+│  │  Selection System                                                 │  │
+│  │   InteractionContext / selectedIds                                │  │
+│  │            │                                                      │  │
+│  │            ▼                                                      │  │
+│  │      DigestButton  ───────────────► useDigest hook               │  │
+│  │                                (request + persistence + zen lock) │  │
+│  │                                            │                      │  │
+│  │                                            ▼                      │  │
+│  │                                       DigestOverlay               │  │
+│  │                             (portal + gestures + markdown html)   │  │
+│  └───────────────────────────────────────┬───────────────────────────┘  │
+└──────────────────────────────────────────│───────────────────────────────┘
+                                           │ HTTP
+                                           ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Flask Backend                                                          │
+│                                                                         │
+│  serve.py (/api/digest)                                                │
+│          │                                                              │
+│          ▼                                                              │
+│  tldr_app.generate_digest                                               │
+│          │                                                              │
+│          ▼                                                              │
+│  tldr_service.generate_digest                                           │
+│   ├─ parallel url_to_markdown()                                         │
+│   ├─ build digest prompt                                                │
+│   ├─ call Gemini                                                        │
+│   └─ cache get/set via storage_service                                 │
+└───────────────────────────────────────┬─────────────────────────────────┘
+                                        │
+                                        ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│ External Systems                                                        │
+│  - Article sources (scrape via existing summarizer pipeline)           │
+│  - Gemini API (generateContent)                                        │
+│  - Supabase PostgreSQL (digests table)                                 │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Sequence Diagram (Time)
+
+> Focus: Runtime order from selection to visible digest.
+
+```text
+TIME   ACTOR                 ACTION                                  TARGET
+│
+├───►  User                  Selects 2+ articles                     Selection system
+│
+├───►  User                  Taps Digest                             DigestButton
+│
+├───►  DigestButton          Builds descriptors from payloads        useDigest.trigger()
+│
+├───►  useDigest             Writes LOADING digest patch             daily payload (selected date)
+│
+├───►  useDigest             POST /api/digest                        serve.py
+│
+├───►  serve.py              Delegates                               tldr_app.generate_digest()
+│
+├───►  tldr_app              Delegates                               tldr_service.generate_digest()
+│
+├───►  tldr_service          Canonicalizes URLs                      util.canonicalize_url()
+│
+├───►  tldr_service          Parallel content fetch                  summarizer.url_to_markdown()
+│
+├───►  tldr_service          Cache lookup                            storage_service.get_digest()
+│      │
+│      ├─ cache hit ───────► returns markdown + metadata             client
+│      │
+│      └─ cache miss
+│            ├──► fetch digest prompt                               summarizer._fetch_digest_prompt()
+│            ├──► build prompt                                      summarizer._build_digest_prompt()
+│            ├──► call LLM                                          summarizer._call_llm()
+│            └──► persist                                            storage_service.set_digest()
+│
+├───►  useDigest             Writes AVAILABLE patch + clears select  daily payload + interaction
+│
+└───►  useDigest             Acquires zen lock + opens overlay       DigestOverlay
+```
+
+---
+
+## Data Flow Diagram (Matter)
+
+> Focus: How data is transformed across the digest pipeline.
+
+```text
+[Selection IDs]      [Descriptor Build]      [Backend Synthesis]         [Persist + Render]
+
+selectedIds ──────►  [{url,title,category}] ──► canonical URLs
+                                           └──► parallel markdown fetch
+                                           └──► digest prompt assembly
+                                           └──► Gemini digest markdown
+                                                  │
+                                                  ▼
+                                       {digest_id, digest_markdown,
+                                        included_urls, article_count, skipped}
+                                                  │
+                                                  ▼
+                                client digest patch stored under
+                                daily payload.digest (selected target date)
+                                                  │
+                                                  ▼
+                                  marked.parse + DOMPurify.sanitize
+                                                  │
+                                                  ▼
+                                         DigestOverlay HTML display
+```
+
+---
+
+## Digest State Machine
+
+### Client data state (`payload.digest.status`)
+
+- `unknown` (implicit initial)
+- `loading` (request in-flight)
+- `available` (digest markdown ready)
+- `error` (request failed)
+
+Transitions:
+
+1. Trigger digest with valid selection → `loading`
+2. Successful response → `available`
+3. Failed response / exception (except abort) → `error`
+4. Abort request → no transition to error; last persisted state remains
+
+### Client view state (`expanded`)
+
+- `collapsed`
+- `expanded`
+
+Transitions:
+
+1. Successful digest result + zen lock acquired → `expanded`
+2. Close action (button, gesture, escape) → `collapsed`
+
+Zen lock is shared with article summary overlays so only one zen overlay can be active.
+
+---
+
+## Call Graph (Logic)
+
+```text
+AppContent()
+├── useInteraction()
+├── useDigest(results)
+├── DigestButton.onTrigger()
+│   └── useDigest.trigger(articleDescriptors)
+│       ├── writeDigest(status=loading)
+│       ├── fetch('/api/digest')
+│       ├── success path
+│       │   ├── writeDigest(status=available, markdown, urls, metadata)
+│       │   ├── clearSelection()
+│       │   └── expand() -> acquireZenLock('digest')
+│       └── error path
+│           └── writeDigest(status=error, errorMessage)
+└── DigestOverlay(html, expanded, ...)
+
+Flask route stack
+serve.digest_endpoint()
+└── tldr_app.generate_digest(articles, effort)
+    └── tldr_service.generate_digest(articles, effort)
+        ├── normalize_summarize_effort()
+        ├── util.canonicalize_url() per article
+        ├── _fetch_articles_content_parallel()
+        │   └── summarizer.url_to_markdown() per article (ThreadPoolExecutor)
+        ├── storage_service.get_digest(digest_id)
+        ├── summarizer._fetch_digest_prompt()
+        ├── summarizer._build_digest_prompt()
+        ├── summarizer._call_llm()
+        └── storage_service.set_digest(...)
+```
+
+---
+
+## API Contract
+
+### `POST /api/digest`
+
+Request body:
+
+```json
+{
+  "articles": [
+    {"url": "https://...", "title": "...", "category": "..."}
+  ],
+  "effort": "low"
+}
+```
+
+Successful response:
+
+```json
+{
+  "success": true,
+  "digest_id": "<sha256>",
+  "digest_markdown": "...",
+  "article_count": 3,
+  "included_urls": ["..."],
+  "skipped": [{"url": "...", "reason": "..."}]
+}
+```
+
+---
+
+## Persistence Model
+
+Digest data is persisted in two places with different roles:
+
+1. **Server cache (canonical digest artifact)**
+   - `digests` table keyed by `digest_id`.
+   - Enables backend cache hits for identical canonical URL-set + effort.
+
+2. **Client daily payload (UI-local recall for selected date context)**
+   - `payload.digest` stored under the most recent selected date key.
+   - Preserved in client merge flow (`mergePreservingLocalState`).
+


### PR DESCRIPTION
### Motivation

- Prevent generating a digest for invalid selections and ensure the UI shows/loading state immediately when a request starts.
- Ensure in-flight requests and the shared zen lock are cleaned up on unmount to avoid stale locks or leaking controllers.
- Document the Digest feature architecture, dataflow, and API for maintainers and reviewers.

### Description

- Added `useEffect` import and a cleanup effect that releases the `DIGEST_LOCK_OWNER` zen lock and aborts any in-flight `AbortController` on unmount via `useEffect(() => () => { ... }, [])`.
- Added guard checks in `trigger` to return early when `results.payloads` is empty, when `articleDescriptors` has fewer than two items, or when no target `date` can be found, to avoid spurious requests.
- Persist a LOADING patch to the client digest state via `writeDigest` before starting the fetch, and moved `requestTokenRef` clearing and `setTriggering(false)` into a `finally` block to centralize cleanup and avoid duplicated state updates.
- Added `docs/DIGEST.md` with the Digest feature architecture, sequence and data-flow diagrams, API contract, and state machine documentation.

### Testing

- Ran the client test suite with `yarn test` and linters with `yarn lint`, and they passed locally.
- Verified a development build with `yarn build` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c94fb8a9b88332953ef32044352fd2)