### PR TITLE
feat(client): integrate digest lifecycle with article state transitions

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -118,7 +118,8 @@ function AppContent({ results, setResults, showSettings, setShowSettings }) {
         expanded={digest.expanded}
         articleCount={digest.articleCount}
         errorMessage={digest.errorMessage}
-        onClose={digest.collapse}
+        onClose={() => digest.collapse(false)}
+        onMarkRemoved={() => digest.collapse(true)}
       />
     </div>
   )

--- a/client/src/components/DigestOverlay.jsx
+++ b/client/src/components/DigestOverlay.jsx
@@ -5,7 +5,7 @@ import { useOverscrollUp } from '../hooks/useOverscrollUp'
 import { usePullToClose } from '../hooks/usePullToClose'
 import { useScrollProgress } from '../hooks/useScrollProgress'
 
-function DigestOverlay({ html, expanded, articleCount, errorMessage, onClose }) {
+function DigestOverlay({ html, expanded, articleCount, errorMessage, onClose, onMarkRemoved }) {
   const [hasScrolled, setHasScrolled] = useState(false)
   const containerRef = useRef(null)
   const scrollRef = useRef(null)
@@ -13,7 +13,7 @@ function DigestOverlay({ html, expanded, articleCount, errorMessage, onClose }) 
   const { pullOffset } = usePullToClose({ containerRef, scrollRef, onClose })
   const { overscrollOffset, isOverscrolling, progress: overscrollProgress, isComplete: overscrollComplete } = useOverscrollUp({
     scrollRef,
-    onComplete: onClose,
+    onComplete: onMarkRemoved,
     threshold: 60
   })
 
@@ -74,7 +74,7 @@ function DigestOverlay({ html, expanded, articleCount, errorMessage, onClose }) 
           </div>
 
           <button
-            onClick={onClose}
+            onClick={onMarkRemoved}
             className="shrink-0 p-2 rounded-full hover:bg-green-100 text-slate-500 hover:text-green-600 transition-colors"
           >
             <Check size={20} />

--- a/client/src/hooks/useDigest.js
+++ b/client/src/hooks/useDigest.js
@@ -56,6 +56,42 @@ export function useDigest(results) {
   const isError = status === summaryDataReducer.SummaryDataStatus.ERROR
   const articleCount = data?.articleUrls?.length ?? 0
 
+  const updateDigestArticles = (articleUrls, updater) => {
+    const urlSet = new Set(articleUrls)
+    setPayloadRef.current(current => {
+      if (!current) return current
+      let didChange = false
+      const nextArticles = current.articles.map(article => {
+        if (!urlSet.has(article.url)) return article
+        didChange = true
+        return updater(article)
+      })
+      if (!didChange) return current
+      return { ...current, articles: nextArticles }
+    })
+  }
+
+  const markDigestArticlesLoading = (articleUrls) => {
+    updateDigestArticles(articleUrls, article => ({
+      ...article,
+      summary: {
+        ...(article.summary || {}),
+        status: summaryDataReducer.SummaryDataStatus.LOADING,
+        effort: 'low',
+        errorMessage: null,
+      },
+    }))
+  }
+
+  const markDigestArticlesConsumed = (articleUrls, shouldRemove) => {
+    const markedAt = new Date().toISOString()
+    updateDigestArticles(articleUrls, article => ({
+      ...article,
+      read: { isRead: true, markedAt },
+      removed: shouldRemove ? true : article.removed,
+    }))
+  }
+
   const writeDigest = (digestPatch) => {
     setPayloadRef.current(current => {
       if (!current) return current
@@ -111,6 +147,8 @@ export function useDigest(results) {
 
     const runDigest = async () => {
       try {
+        markDigestArticlesLoading(articleUrls)
+
         writeDigest({
           status: summaryDataReducer.SummaryDataStatus.LOADING,
           effort: 'low',
@@ -177,7 +215,10 @@ export function useDigest(results) {
     }
   }
 
-  const collapse = () => {
+  const collapse = (shouldRemove = false) => {
+    if (status === summaryDataReducer.SummaryDataStatus.AVAILABLE && data?.articleUrls?.length > 0) {
+      markDigestArticlesConsumed(data.articleUrls, shouldRemove)
+    }
     logTransition('digest-view', DIGEST_LOCK_OWNER, 'expanded', 'collapsed')
     releaseZenLock(DIGEST_LOCK_OWNER)
     setExpanded(false)

--- a/client/src/hooks/useDigest.js
+++ b/client/src/hooks/useDigest.js
@@ -73,29 +73,45 @@ export function useDigest(results) {
   }, [])
 
   const markDigestArticlesLoading = useCallback((articleUrls) => {
-    updateDigestArticles(articleUrls, article => ({
-      ...article,
-      summary: {
-        ...(article.summary || {}),
-        ...summaryDataReducer.reduceSummaryData(article.summary, {
-          type: summaryDataReducer.SummaryDataEventType.SUMMARY_REQUESTED,
-          effort: 'low',
-        }).patch,
-      },
-    }))
+    const previousSummaryByUrl = new Map()
+    updateDigestArticles(articleUrls, article => {
+      previousSummaryByUrl.set(article.url, article.summary)
+      return {
+        ...article,
+        summary: {
+          ...(article.summary || {}),
+          ...summaryDataReducer.reduceSummaryData(article.summary, {
+            type: summaryDataReducer.SummaryDataEventType.SUMMARY_REQUESTED,
+            effort: 'low',
+          }).patch,
+        },
+      }
+    })
+    return previousSummaryByUrl
+  }, [updateDigestArticles])
+
+  const restoreDigestArticlesSummary = useCallback((articleUrls, previousSummaryByUrl) => {
+    if (!previousSummaryByUrl) return
+    updateDigestArticles(articleUrls, article => {
+      const previousSummary = previousSummaryByUrl.get(article.url)
+      if (previousSummary == null) {
+        const { summary, ...rest } = article
+        return rest
+      }
+      return { ...article, summary: previousSummary }
+    })
   }, [updateDigestArticles])
 
   const markDigestArticlesConsumed = useCallback((articleUrls, shouldRemove) => {
     const markedAt = new Date().toISOString()
     updateDigestArticles(articleUrls, article => ({
       ...article,
-      ...reduceArticleLifecycle(article, {
-        type: ArticleLifecycleEventType.MARK_READ,
-        markedAt,
-      }).patch,
       ...(shouldRemove
         ? reduceArticleLifecycle(article, { type: ArticleLifecycleEventType.MARK_REMOVED }).patch
-        : {}),
+        : reduceArticleLifecycle(article, {
+            type: ArticleLifecycleEventType.MARK_READ,
+            markedAt,
+          }).patch),
     }))
   }, [updateDigestArticles])
 
@@ -160,8 +176,9 @@ export function useDigest(results) {
     setPendingRequest(null)
 
     const runDigest = async () => {
+      let previousSummaryByUrl
       try {
-        markDigestArticlesLoading(articleUrls)
+        previousSummaryByUrl = markDigestArticlesLoading(articleUrls)
 
         writeDigest({
           status: summaryDataReducer.SummaryDataStatus.LOADING,
@@ -181,6 +198,7 @@ export function useDigest(results) {
         if (requestTokenRef.current !== requestToken) return
 
         if (result.success) {
+          restoreDigestArticlesSummary(articleUrls, previousSummaryByUrl)
           const successPatch = {
             status: summaryDataReducer.SummaryDataStatus.AVAILABLE,
             markdown: result.digest_markdown,
@@ -205,8 +223,10 @@ export function useDigest(results) {
         })
       } catch (error) {
         if (error.name === 'AbortError') {
+          restoreDigestArticlesSummary(articleUrls, previousSummaryByUrl)
           return
         }
+        restoreDigestArticlesSummary(articleUrls, previousSummaryByUrl)
         writeDigest({
           status: summaryDataReducer.SummaryDataStatus.ERROR,
           errorMessage: error.message,
@@ -220,7 +240,7 @@ export function useDigest(results) {
     }
 
     void runDigest()
-  }, [pendingRequest, payload, targetDate, clearSelection, expand, markDigestArticlesLoading, writeDigest])
+  }, [pendingRequest, payload, targetDate, clearSelection, expand, markDigestArticlesLoading, restoreDigestArticlesSummary, writeDigest])
 
   const collapse = useCallback((shouldRemove = false) => {
     if (status === summaryDataReducer.SummaryDataStatus.AVAILABLE && data?.articleUrls?.length > 0) {

--- a/client/src/hooks/useDigest.js
+++ b/client/src/hooks/useDigest.js
@@ -1,9 +1,10 @@
 import DOMPurify from 'dompurify'
 import { marked } from 'marked'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useInteraction } from '../contexts/InteractionContext'
 import { logTransition } from '../lib/stateTransitionLogger'
 import { getNewsletterScrapeKey } from '../lib/storageKeys'
+import { ArticleLifecycleEventType, reduceArticleLifecycle } from '../reducers/articleLifecycleReducer'
 import * as summaryDataReducer from '../reducers/summaryDataReducer'
 import { acquireZenLock, releaseZenLock } from './useSummary'
 import { useSupabaseStorage } from './useSupabaseStorage'
@@ -56,7 +57,7 @@ export function useDigest(results) {
   const isError = status === summaryDataReducer.SummaryDataStatus.ERROR
   const articleCount = data?.articleUrls?.length ?? 0
 
-  const updateDigestArticles = (articleUrls, updater) => {
+  const updateDigestArticles = useCallback((articleUrls, updater) => {
     const urlSet = new Set(articleUrls)
     setPayloadRef.current(current => {
       if (!current) return current
@@ -69,30 +70,36 @@ export function useDigest(results) {
       if (!didChange) return current
       return { ...current, articles: nextArticles }
     })
-  }
+  }, [])
 
-  const markDigestArticlesLoading = (articleUrls) => {
+  const markDigestArticlesLoading = useCallback((articleUrls) => {
     updateDigestArticles(articleUrls, article => ({
       ...article,
       summary: {
         ...(article.summary || {}),
-        status: summaryDataReducer.SummaryDataStatus.LOADING,
-        effort: 'low',
-        errorMessage: null,
+        ...summaryDataReducer.reduceSummaryData(article.summary, {
+          type: summaryDataReducer.SummaryDataEventType.SUMMARY_REQUESTED,
+          effort: 'low',
+        }).patch,
       },
     }))
-  }
+  }, [updateDigestArticles])
 
-  const markDigestArticlesConsumed = (articleUrls, shouldRemove) => {
+  const markDigestArticlesConsumed = useCallback((articleUrls, shouldRemove) => {
     const markedAt = new Date().toISOString()
     updateDigestArticles(articleUrls, article => ({
       ...article,
-      read: { isRead: true, markedAt },
-      removed: shouldRemove ? true : article.removed,
+      ...reduceArticleLifecycle(article, {
+        type: ArticleLifecycleEventType.MARK_READ,
+        markedAt,
+      }).patch,
+      ...(shouldRemove
+        ? reduceArticleLifecycle(article, { type: ArticleLifecycleEventType.MARK_REMOVED }).patch
+        : {}),
     }))
-  }
+  }, [updateDigestArticles])
 
-  const writeDigest = (digestPatch) => {
+  const writeDigest = useCallback((digestPatch) => {
     setPayloadRef.current(current => {
       if (!current) return current
       const fromStatus = summaryDataReducer.getSummaryDataStatus(current.digest)
@@ -102,7 +109,7 @@ export function useDigest(results) {
       }
       return { ...current, digest: { ...(current.digest || {}), ...digestPatch } }
     })
-  }
+  }, [])
 
   const createRequestToken = () => `${Date.now()}-${Math.random().toString(16).slice(2)}`
 
@@ -133,6 +140,13 @@ export function useDigest(results) {
     setTargetDate(date)
     setTriggering(true)
   }
+
+  const expand = useCallback(() => {
+    if (acquireZenLock(DIGEST_LOCK_OWNER)) {
+      logTransition('digest-view', DIGEST_LOCK_OWNER, 'collapsed', 'expanded', 'tap')
+      setExpanded(true)
+    }
+  }, [])
 
   useEffect(() => {
     if (!pendingRequest) return
@@ -206,23 +220,16 @@ export function useDigest(results) {
     }
 
     void runDigest()
-  }, [pendingRequest, payload, targetDate, clearSelection])
+  }, [pendingRequest, payload, targetDate, clearSelection, expand, markDigestArticlesLoading, writeDigest])
 
-  const expand = () => {
-    if (acquireZenLock(DIGEST_LOCK_OWNER)) {
-      logTransition('digest-view', DIGEST_LOCK_OWNER, 'collapsed', 'expanded', 'tap')
-      setExpanded(true)
-    }
-  }
-
-  const collapse = (shouldRemove = false) => {
+  const collapse = useCallback((shouldRemove = false) => {
     if (status === summaryDataReducer.SummaryDataStatus.AVAILABLE && data?.articleUrls?.length > 0) {
       markDigestArticlesConsumed(data.articleUrls, shouldRemove)
     }
     logTransition('digest-view', DIGEST_LOCK_OWNER, 'expanded', 'collapsed')
     releaseZenLock(DIGEST_LOCK_OWNER)
     setExpanded(false)
-  }
+  }, [status, data, markDigestArticlesConsumed])
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
### Motivation
- Make the digest UX follow the same article lifecycle semantics as single-article summaries so selected articles are visibly in a `loading` state when a digest request is in-flight and are marked `read`/`removed` when the digest overlay is dismissed.

### Description
- Added article-state helpers to `useDigest` (`updateDigestArticles`, `markDigestArticlesLoading`, `markDigestArticlesConsumed`) and mark selected articles' `summary.status` as `loading` when a digest request starts. 
- On successful digest generation the hook writes the digest to the day payload, clears selection and expands the digest overlay; collapsing the overlay now applies lifecycle updates (mark-as-read on normal close, mark-as-removed on remove action).
- Updated `DigestOverlay` to accept `onMarkRemoved` and wired its overscroll & check actions to call `onMarkRemoved` (preserving `onClose` for normal close). 
- Wired the new overlay callbacks in `App.jsx` so `onClose` calls `digest.collapse(false)` and the remove action calls `digest.collapse(true)` to toggle whether included articles become `removed`.

Files changed: `client/src/hooks/useDigest.js`, `client/src/components/DigestOverlay.jsx`, `client/src/App.jsx`.

### Testing
- Performed a production frontend build: ran `cd client && npm install` and then `cd client && npm run build`; `npm install` completed and `vite` build succeeded without errors. 
- No unit test suites were executed as part of this change; build output was used to verify there are no runtime bundling errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce705985c4833288645743ed2ae7ff)