### PR TITLE
fix(client): preserve article summary state after digest lifecycle writes & align summarize icon

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -115,8 +115,14 @@ function AppContent({ results, setResults, showSettings, setShowSettings }) {
   })
   const selectedArticles = getSelectedArticles(selectedIds, results?.payloads)
   const selectedDescriptors = extractSelectedArticleDescriptors(selectedArticles)
-  const selectedCount = selectedArticles.length
-  const singleSelectedArticle = selectedCount === 1 ? selectedArticles[0] : null
+  const selectedCount = selectedIds.size
+  const singleSelectedId = selectedCount === 1 ? [...selectedIds][0] : null
+  const singleSelectedUrl = singleSelectedId?.startsWith('article-')
+    ? singleSelectedId.slice('article-'.length)
+    : null
+  const singleSelectedArticle = singleSelectedUrl
+    ? selectedArticles.find((article) => article.url === singleSelectedUrl) || null
+    : null
   const singleSummaryStatus = summaryDataReducer.getSummaryDataStatus(singleSelectedArticle?.summary)
   const canOpenSingleSummary = singleSummaryStatus === summaryDataReducer.SummaryDataStatus.AVAILABLE
   const isSingleSummaryLoading = singleSummaryStatus === summaryDataReducer.SummaryDataStatus.LOADING

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,11 +7,14 @@ import SelectionActionDock from './components/SelectionActionDock'
 import ToastContainer from './components/ToastContainer'
 import { InteractionProvider, useInteraction } from './contexts/InteractionContext'
 import { useDigest } from './hooks/useDigest'
-import { mergeIntoCache } from './hooks/useSupabaseStorage'
+import { getCachedStorageValue, mergeIntoCache, setStorageValueAsync } from './hooks/useSupabaseStorage'
+import { publishArticleAction } from './lib/articleActionBus'
 import { scrapeNewsletters } from './lib/scraper'
 import { logTransition } from './lib/stateTransitionLogger'
 import { getDailyPayloadsRange } from './lib/storageApi'
 import { getNewsletterScrapeKey } from './lib/storageKeys'
+import { ArticleLifecycleEventType, reduceArticleLifecycle } from './reducers/articleLifecycleReducer'
+import * as summaryDataReducer from './reducers/summaryDataReducer'
 
 const SERVER_ORIGIN_FIELDS = ['url', 'title', 'articleMeta', 'issueDate', 'category', 'sourceId', 'section', 'sectionEmoji', 'sectionOrder', 'newsletterType']
 
@@ -32,27 +35,143 @@ function mergePreservingLocalState(freshPayload, localPayload) {
   }
 }
 
-function extractSelectedArticleDescriptors(selectedIds, payloads) {
+function getLivePayload(date, fallbackPayloads) {
+  const live = getCachedStorageValue(getNewsletterScrapeKey(date))
+  if (live) return live
+  return fallbackPayloads?.find((payload) => payload.date === date) || null
+}
+
+function getSelectedArticles(selectedIds, payloads) {
   if (!payloads) return []
-  const allArticles = payloads.flatMap((payload) => payload.articles)
-  return allArticles
-    .filter((article) => selectedIds.has(`article-${article.url}`))
-    .map(({ url, title, category, sourceId }) => ({ url, title, category, sourceId }))
+  const selectedArticles = []
+
+  for (const payload of payloads) {
+    const livePayload = getLivePayload(payload.date, payloads)
+    if (!livePayload?.articles) continue
+
+    for (const article of livePayload.articles) {
+      if (selectedIds.has(`article-${article.url}`)) {
+        selectedArticles.push(article)
+      }
+    }
+  }
+
+  return selectedArticles
+}
+
+function extractSelectedArticleDescriptors(selectedArticles) {
+  return selectedArticles.map(({ url, title, category, sourceId }) => ({ url, title, category, sourceId }))
+}
+
+function groupSelectedByDate(selectedArticles) {
+  const grouped = new Map()
+  for (const article of selectedArticles) {
+    if (!grouped.has(article.issueDate)) grouped.set(article.issueDate, [])
+    grouped.get(article.issueDate).push(article)
+  }
+  return grouped
+}
+
+function toBrowserUrl(url) {
+  if (url.startsWith('http://') || url.startsWith('https://')) return url
+  return `https://${url}`
+}
+
+async function applyBatchLifecyclePatch(selectedArticles, eventFactory) {
+  const groupedByDate = groupSelectedByDate(selectedArticles)
+
+  for (const [date, articles] of groupedByDate.entries()) {
+    const urlSet = new Set(articles.map((article) => article.url))
+    const storageKey = getNewsletterScrapeKey(date)
+    await setStorageValueAsync(storageKey, (current) => {
+      if (!current) return current
+      return {
+        ...current,
+        articles: current.articles.map((article) => {
+          if (!urlSet.has(article.url)) return article
+          const event = eventFactory(article)
+          return { ...article, ...reduceArticleLifecycle(article, event).patch }
+        })
+      }
+    })
+  }
 }
 
 function AppContent({ results, setResults, showSettings, setShowSettings }) {
   const { selectedIds, isSelectMode, clearSelection } = useInteraction()
   const digest = useDigest(results)
+  const [, setStorageVersion] = useState(0)
+
+  useEffect(() => {
+    const handleStorageChange = () => setStorageVersion((version) => version + 1)
+    window.addEventListener('supabase-storage-change', handleStorageChange)
+    return () => window.removeEventListener('supabase-storage-change', handleStorageChange)
+  }, [])
 
   const currentDate = new Date().toLocaleDateString('en-US', {
     weekday: 'long',
     month: 'long',
     day: 'numeric'
   })
+  const selectedArticles = getSelectedArticles(selectedIds, results?.payloads)
+  const selectedDescriptors = extractSelectedArticleDescriptors(selectedArticles)
+  const selectedCount = selectedArticles.length
+  const singleSelectedArticle = selectedCount === 1 ? selectedArticles[0] : null
+  const singleSummaryStatus = summaryDataReducer.getSummaryDataStatus(singleSelectedArticle?.summary)
+  const canOpenSingleSummary = singleSummaryStatus === summaryDataReducer.SummaryDataStatus.AVAILABLE
+  const isSingleSummaryLoading = singleSummaryStatus === summaryDataReducer.SummaryDataStatus.LOADING
+  const summarizeEachActionableCount = selectedArticles.filter((article) => {
+    const status = summaryDataReducer.getSummaryDataStatus(article.summary)
+    return status === summaryDataReducer.SummaryDataStatus.UNKNOWN || status === summaryDataReducer.SummaryDataStatus.ERROR
+  }).length
+  const isSummarizeEachDisabled = selectedCount < 2 || summarizeEachActionableCount === 0
 
   function handleTriggerDigest() {
-    const descriptors = extractSelectedArticleDescriptors(selectedIds, results?.payloads)
-    digest.trigger(descriptors)
+    digest.trigger(selectedDescriptors)
+  }
+
+  async function handleMarkSelectedRead() {
+    if (selectedArticles.length === 0) return
+    const markedAt = new Date().toISOString()
+    await applyBatchLifecyclePatch(selectedArticles, () => ({
+      type: ArticleLifecycleEventType.MARK_READ,
+      markedAt,
+    }))
+    clearSelection()
+  }
+
+  async function handleMarkSelectedRemoved() {
+    if (selectedArticles.length === 0) return
+    await applyBatchLifecyclePatch(selectedArticles, () => ({
+      type: ArticleLifecycleEventType.MARK_REMOVED,
+    }))
+    clearSelection()
+  }
+
+  function handleSummarizeSingle() {
+    if (!singleSelectedArticle) return
+    if (canOpenSingleSummary) {
+      publishArticleAction([singleSelectedArticle.url], 'open-summary')
+      return
+    }
+    publishArticleAction([singleSelectedArticle.url], 'fetch-summary')
+  }
+
+  function handleBrowseSingle() {
+    if (!singleSelectedArticle) return
+    window.open(toBrowserUrl(singleSelectedArticle.url), '_blank', 'noopener,noreferrer')
+  }
+
+  function handleSummarizeEach() {
+    if (selectedCount < 2) return
+    const actionableUrls = selectedArticles
+      .filter((article) => {
+        const status = summaryDataReducer.getSummaryDataStatus(article.summary)
+        return status === summaryDataReducer.SummaryDataStatus.UNKNOWN || status === summaryDataReducer.SummaryDataStatus.ERROR
+      })
+      .map((article) => article.url)
+    if (actionableUrls.length === 0) return
+    publishArticleAction(actionableUrls, 'fetch-summary')
   }
 
   return (
@@ -128,10 +247,18 @@ function AppContent({ results, setResults, showSettings, setShowSettings }) {
 
       <SelectionActionDock
         isSelectMode={isSelectMode}
-        selectedCount={selectedIds.size}
+        selectedCount={selectedCount}
         isDigestLoading={digest.loading}
+        canOpenSingleSummary={canOpenSingleSummary}
+        isSingleSummaryLoading={isSingleSummaryLoading}
+        isSummarizeEachDisabled={isSummarizeEachDisabled}
         onClearSelection={clearSelection}
+        onMarkRead={handleMarkSelectedRead}
+        onMarkRemoved={handleMarkSelectedRemoved}
         onTriggerDigest={handleTriggerDigest}
+        onSummarizeSingle={handleSummarizeSingle}
+        onBrowseSingle={handleBrowseSingle}
+        onSummarizeEach={handleSummarizeEach}
       />
     </div>
   )

--- a/client/src/components/ArticleCard.jsx
+++ b/client/src/components/ArticleCard.jsx
@@ -9,6 +9,7 @@ import { usePullToClose } from '../hooks/usePullToClose'
 import { useScrollProgress } from '../hooks/useScrollProgress'
 import { useSummary } from '../hooks/useSummary'
 import { useSwipeToRemove } from '../hooks/useSwipeToRemove'
+import { subscribeToArticleAction } from '../lib/articleActionBus'
 import Selectable from './Selectable'
 
 function ErrorToast({ message, onDismiss }) {
@@ -282,6 +283,23 @@ function ArticleCard({ article }) {
     registerDisabled(componentId, isRemoved)
     return () => registerDisabled(componentId, false)
   }, [componentId, isRemoved, registerDisabled])
+
+  useEffect(() => {
+    return subscribeToArticleAction(article.url, (action) => {
+      if (isRemoved) return
+
+      if (action === 'open-summary') {
+        if (summary.isAvailable) summary.expand()
+        return
+      }
+
+      if (action === 'fetch-summary') {
+        if (summary.status === 'unknown' || summary.status === 'error') {
+          summary.fetch()
+        }
+      }
+    })
+  }, [article.url, isRemoved, summary])
 
   return (
     <Selectable id={componentId} disabled={isRemoved}>

--- a/client/src/components/SelectionActionDock.jsx
+++ b/client/src/components/SelectionActionDock.jsx
@@ -1,4 +1,4 @@
-import { BookOpen, Check, ExternalLink, FileText, GitMerge, Sparkles, Trash2, X } from 'lucide-react'
+import { BookOpen, Check, ExternalLink, GitMerge, Sparkles, Trash2, X } from 'lucide-react'
 
 function DockButton({ label, icon, onClick, disabled = false, danger = false, accent = false, style }) {
   const buttonBaseClassName = 'group flex min-w-16 flex-col items-center gap-1 rounded-xl px-2 py-1 text-slate-100 transition-all duration-200 ease-[var(--ease-springy)] hover:-translate-y-0.5 hover:text-white active:translate-y-0 active:scale-[0.96] disabled:opacity-35 disabled:hover:translate-y-0 disabled:hover:text-slate-100 disabled:active:scale-100 motion-safe:animate-dock-action-enter'
@@ -90,7 +90,7 @@ function SelectionActionDock({
     actions.push({
       key: 'summarize-each',
       label: 'Summarize Each',
-      icon: <FileText size={21} />,
+      icon: <Sparkles size={21} />,
       onClick: onSummarizeEach,
       disabled: isSummarizeEachDisabled,
     })

--- a/client/src/components/SelectionActionDock.jsx
+++ b/client/src/components/SelectionActionDock.jsx
@@ -1,8 +1,100 @@
-import { GitMerge, X } from 'lucide-react'
+import { BookOpen, Check, ExternalLink, FileText, GitMerge, Sparkles, Trash2, X } from 'lucide-react'
 
-function SelectionActionDock({ isSelectMode, selectedCount, isDigestLoading, onClearSelection, onTriggerDigest }) {
-  const isDigestDisabled = selectedCount < 2 || isDigestLoading
-  const buttonBaseClassName = 'group flex min-w-20 flex-col items-center gap-1 rounded-xl px-3 py-1 text-slate-100 transition-all duration-200 ease-[var(--ease-springy)] hover:-translate-y-0.5 hover:text-white active:translate-y-0 active:scale-[0.96] disabled:opacity-35 disabled:hover:translate-y-0 disabled:hover:text-slate-100 disabled:active:scale-100 motion-safe:animate-dock-action-enter'
+function DockButton({ label, icon, onClick, disabled = false, danger = false, accent = false, style }) {
+  const buttonBaseClassName = 'group flex min-w-16 flex-col items-center gap-1 rounded-xl px-2 py-1 text-slate-100 transition-all duration-200 ease-[var(--ease-springy)] hover:-translate-y-0.5 hover:text-white active:translate-y-0 active:scale-[0.96] disabled:opacity-35 disabled:hover:translate-y-0 disabled:hover:text-slate-100 disabled:active:scale-100 motion-safe:animate-dock-action-enter'
+  const iconClassName = [
+    'flex h-11 w-11 items-center justify-center rounded-full transition-transform duration-200 ease-[var(--ease-springy)] group-hover:scale-105 group-active:scale-95',
+    accent ? 'bg-brand-500/85 text-white' : '',
+    danger ? 'bg-red-500/75 text-white' : '',
+    !accent && !danger ? 'bg-white/10 text-white' : '',
+  ].join(' ')
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={buttonBaseClassName}
+      style={style}
+      aria-label={label}
+    >
+      <span className={iconClassName}>{icon}</span>
+      <span className="text-xs font-medium tracking-wide text-center leading-none">{label}</span>
+    </button>
+  )
+}
+
+function SelectionActionDock({
+  isSelectMode,
+  selectedCount,
+  isDigestLoading,
+  canOpenSingleSummary,
+  isSingleSummaryLoading,
+  isSummarizeEachDisabled,
+  onClearSelection,
+  onMarkRead,
+  onMarkRemoved,
+  onTriggerDigest,
+  onSummarizeSingle,
+  onBrowseSingle,
+  onSummarizeEach,
+}) {
+  const actions = [
+    {
+      key: 'deselect',
+      label: 'Deselect',
+      icon: <X size={21} />,
+      onClick: onClearSelection,
+    },
+    {
+      key: 'read',
+      label: 'Read',
+      icon: <Check size={21} />,
+      onClick: onMarkRead,
+    },
+    {
+      key: 'remove',
+      label: 'Remove',
+      icon: <Trash2 size={21} />,
+      onClick: onMarkRemoved,
+      danger: true,
+    },
+  ]
+
+  if (selectedCount === 1) {
+    actions.push({
+      key: 'summarize-single',
+      label: canOpenSingleSummary ? 'Open' : (isSingleSummaryLoading ? 'Loading...' : 'Summarize'),
+      icon: canOpenSingleSummary ? <BookOpen size={21} /> : <Sparkles size={21} />,
+      onClick: onSummarizeSingle,
+      disabled: isSingleSummaryLoading,
+      accent: true,
+    })
+    actions.push({
+      key: 'browse',
+      label: 'Browse',
+      icon: <ExternalLink size={21} />,
+      onClick: onBrowseSingle,
+    })
+  }
+
+  if (selectedCount > 1) {
+    actions.push({
+      key: 'digest',
+      label: isDigestLoading ? 'Loading...' : 'Digest',
+      icon: <GitMerge size={21} />,
+      onClick: onTriggerDigest,
+      disabled: isDigestLoading,
+      accent: true,
+    })
+    actions.push({
+      key: 'summarize-each',
+      label: 'Summarize Each',
+      icon: <FileText size={21} />,
+      onClick: onSummarizeEach,
+      disabled: isSummarizeEachDisabled,
+    })
+  }
 
   return (
     <div
@@ -12,32 +104,19 @@ function SelectionActionDock({ isSelectMode, selectedCount, isDigestLoading, onC
       ].join(' ')}
     >
       <div className="w-full max-w-md rounded-[1.7rem] border border-slate-900/10 bg-slate-950/95 text-white shadow-2xl backdrop-blur-xl">
-        <div className="flex items-center justify-around px-4 py-3">
-          <button
-            type="button"
-            onClick={onClearSelection}
-            className={buttonBaseClassName}
-            aria-label="Clear selection"
-          >
-            <span className="flex h-11 w-11 items-center justify-center rounded-full bg-white/10 transition-transform duration-200 ease-[var(--ease-springy)] group-hover:scale-105 group-active:scale-95">
-              <X size={21} />
-            </span>
-            <span className="text-xs font-medium tracking-wide">Deselect</span>
-          </button>
-
-          <button
-            type="button"
-            onClick={onTriggerDigest}
-            disabled={isDigestDisabled}
-            className={buttonBaseClassName}
-            style={{ animationDelay: '40ms' }}
-            aria-label="Generate digest"
-          >
-            <span className={`flex h-11 w-11 items-center justify-center rounded-full bg-brand-500/85 text-white transition-transform duration-200 ease-[var(--ease-springy)] group-hover:scale-105 group-active:scale-95 ${isDigestLoading ? 'animate-pulse' : ''}`}>
-              <GitMerge size={21} />
-            </span>
-            <span className="text-xs font-medium tracking-wide">{isDigestLoading ? 'Loading...' : 'Digest'}</span>
-          </button>
+        <div className="flex items-start justify-between gap-1 px-2 py-3">
+          {actions.map((action, index) => (
+            <DockButton
+              key={action.key}
+              label={action.label}
+              icon={action.icon}
+              onClick={action.onClick}
+              disabled={action.disabled}
+              danger={action.danger}
+              accent={action.accent}
+              style={{ animationDelay: `${index * 30}ms` }}
+            />
+          ))}
         </div>
       </div>
     </div>

--- a/client/src/hooks/useDigest.js
+++ b/client/src/hooks/useDigest.js
@@ -19,24 +19,6 @@ function findMostRecentDate(articleDescriptors, payloads) {
   return matchingDates.sort().at(-1)
 }
 
-function groupDescriptorsByDate(articleDescriptors, payloads) {
-  const dateByUrl = new Map()
-  for (const payload of payloads) {
-    for (const article of payload.articles) {
-      dateByUrl.set(article.url, payload.date)
-    }
-  }
-
-  const grouped = new Map()
-  for (const descriptor of articleDescriptors) {
-    const date = dateByUrl.get(descriptor.url)
-    if (!date) continue
-    if (!grouped.has(date)) grouped.set(date, [])
-    grouped.get(date).push(descriptor.url)
-  }
-  return grouped
-}
-
 export function useDigest(results) {
   const { clearSelection } = useInteraction()
   const [expanded, setExpanded] = useState(false)
@@ -74,6 +56,26 @@ export function useDigest(results) {
   const loading = triggering
   const isError = status === summaryDataReducer.SummaryDataStatus.ERROR
   const articleCount = data?.articleUrls?.length ?? 0
+
+  const groupDescriptorsByDate = useCallback((articleDescriptors) => {
+    const dateByUrl = new Map()
+    for (const payloadDescriptor of results?.payloads || []) {
+      const storageKey = getNewsletterScrapeKey(payloadDescriptor.date)
+      const livePayload = getCachedStorageValue(storageKey) || payloadDescriptor
+      for (const article of livePayload.articles || []) {
+        dateByUrl.set(article.url, livePayload.date)
+      }
+    }
+
+    const grouped = new Map()
+    for (const descriptor of articleDescriptors) {
+      const date = dateByUrl.get(descriptor.url)
+      if (!date) continue
+      if (!grouped.has(date)) grouped.set(date, [])
+      grouped.get(date).push(descriptor.url)
+    }
+    return grouped
+  }, [results?.payloads])
 
   const updateArticlesAcrossDates = useCallback(async (urlsByDate, updater) => {
     for (const [date, urls] of urlsByDate.entries()) {
@@ -193,7 +195,7 @@ export function useDigest(results) {
     if (!payload || payload.date !== pendingRequest.date) return
 
     const { articleDescriptors, requestToken } = pendingRequest
-    const urlsByDate = groupDescriptorsByDate(articleDescriptors, results?.payloads || [])
+    const urlsByDate = groupDescriptorsByDate(articleDescriptors)
     const articleUrls = articleDescriptors.map(d => d.url)
     const controller = new AbortController()
     abortControllerRef.current = controller
@@ -255,7 +257,7 @@ export function useDigest(results) {
     }
 
     void runDigest()
-  }, [pendingRequest, payload, targetDate, clearSelection, expand, markDigestArticlesLoading, restoreDigestArticlesSummary, writeDigest, results?.payloads])
+  }, [pendingRequest, payload, targetDate, clearSelection, expand, markDigestArticlesLoading, restoreDigestArticlesSummary, writeDigest, groupDescriptorsByDate])
 
   useEffect(() => {
     if (status !== summaryDataReducer.SummaryDataStatus.LOADING) return
@@ -266,17 +268,21 @@ export function useDigest(results) {
   }, [status, writeDigest])
 
   const collapse = useCallback(async (shouldRemove = false) => {
-    if (status === summaryDataReducer.SummaryDataStatus.AVAILABLE && data?.articleUrls?.length > 0) {
-      const urlsByDate = groupDescriptorsByDate(
-        data.articleUrls.map((url) => ({ url })),
-        results?.payloads || []
-      )
-      await markDigestArticlesConsumed(urlsByDate, shouldRemove)
+    try {
+      if (status === summaryDataReducer.SummaryDataStatus.AVAILABLE && data?.articleUrls?.length > 0) {
+        const urlsByDate = groupDescriptorsByDate(
+          data.articleUrls.map((url) => ({ url }))
+        )
+        await markDigestArticlesConsumed(urlsByDate, shouldRemove)
+      }
+    } catch (error) {
+      console.error(`Failed to persist digest consumed lifecycle: ${error.message}`)
+    } finally {
+      logTransition('digest-view', DIGEST_LOCK_OWNER, 'expanded', 'collapsed')
+      releaseZenLock(DIGEST_LOCK_OWNER)
+      setExpanded(false)
     }
-    logTransition('digest-view', DIGEST_LOCK_OWNER, 'expanded', 'collapsed')
-    releaseZenLock(DIGEST_LOCK_OWNER)
-    setExpanded(false)
-  }, [status, data, markDigestArticlesConsumed, results?.payloads])
+  }, [status, data, markDigestArticlesConsumed, groupDescriptorsByDate])
 
   useEffect(() => {
     return () => {

--- a/client/src/hooks/useDigest.js
+++ b/client/src/hooks/useDigest.js
@@ -7,7 +7,7 @@ import { getNewsletterScrapeKey } from '../lib/storageKeys'
 import { ArticleLifecycleEventType, reduceArticleLifecycle } from '../reducers/articleLifecycleReducer'
 import * as summaryDataReducer from '../reducers/summaryDataReducer'
 import { acquireZenLock, releaseZenLock } from './useSummary'
-import { useSupabaseStorage } from './useSupabaseStorage'
+import { getCachedStorageValue, setStorageValueAsync, useSupabaseStorage } from './useSupabaseStorage'
 
 const DIGEST_LOCK_OWNER = 'digest'
 
@@ -17,6 +17,24 @@ function findMostRecentDate(articleDescriptors, payloads) {
     .filter(p => p.articles.some(a => urlSet.has(a.url)))
     .map(p => p.date)
   return matchingDates.sort().at(-1)
+}
+
+function groupDescriptorsByDate(articleDescriptors, payloads) {
+  const dateByUrl = new Map()
+  for (const payload of payloads) {
+    for (const article of payload.articles) {
+      dateByUrl.set(article.url, payload.date)
+    }
+  }
+
+  const grouped = new Map()
+  for (const descriptor of articleDescriptors) {
+    const date = dateByUrl.get(descriptor.url)
+    if (!date) continue
+    if (!grouped.has(date)) grouped.set(date, [])
+    grouped.get(date).push(descriptor.url)
+  }
+  return grouped
 }
 
 export function useDigest(results) {
@@ -57,24 +75,29 @@ export function useDigest(results) {
   const isError = status === summaryDataReducer.SummaryDataStatus.ERROR
   const articleCount = data?.articleUrls?.length ?? 0
 
-  const updateDigestArticles = useCallback((articleUrls, updater) => {
-    const urlSet = new Set(articleUrls)
-    setPayloadRef.current(current => {
-      if (!current) return current
-      let didChange = false
-      const nextArticles = current.articles.map(article => {
-        if (!urlSet.has(article.url)) return article
-        didChange = true
-        return updater(article)
+  const updateArticlesAcrossDates = useCallback(async (urlsByDate, updater) => {
+    for (const [date, urls] of urlsByDate.entries()) {
+      const urlSet = new Set(urls)
+      const storageKey = getNewsletterScrapeKey(date)
+      await setStorageValueAsync(storageKey, (current) => {
+        const liveCurrent = current || getCachedStorageValue(storageKey)
+        if (!liveCurrent) return liveCurrent
+
+        let didChange = false
+        const nextArticles = liveCurrent.articles.map((article) => {
+          if (!urlSet.has(article.url)) return article
+          didChange = true
+          return updater(article)
+        })
+        if (!didChange) return liveCurrent
+        return { ...liveCurrent, articles: nextArticles }
       })
-      if (!didChange) return current
-      return { ...current, articles: nextArticles }
-    })
+    }
   }, [])
 
-  const markDigestArticlesLoading = useCallback((articleUrls) => {
+  const markDigestArticlesLoading = useCallback(async (urlsByDate) => {
     const previousSummaryByUrl = new Map()
-    updateDigestArticles(articleUrls, article => {
+    await updateArticlesAcrossDates(urlsByDate, (article) => {
       previousSummaryByUrl.set(article.url, article.summary)
       return {
         ...article,
@@ -88,11 +111,11 @@ export function useDigest(results) {
       }
     })
     return previousSummaryByUrl
-  }, [updateDigestArticles])
+  }, [updateArticlesAcrossDates])
 
-  const restoreDigestArticlesSummary = useCallback((articleUrls, previousSummaryByUrl) => {
+  const restoreDigestArticlesSummary = useCallback(async (urlsByDate, previousSummaryByUrl) => {
     if (!previousSummaryByUrl) return
-    updateDigestArticles(articleUrls, article => {
+    await updateArticlesAcrossDates(urlsByDate, (article) => {
       const previousSummary = previousSummaryByUrl.get(article.url)
       if (previousSummary == null) {
         const { summary, ...rest } = article
@@ -100,11 +123,11 @@ export function useDigest(results) {
       }
       return { ...article, summary: previousSummary }
     })
-  }, [updateDigestArticles])
+  }, [updateArticlesAcrossDates])
 
-  const markDigestArticlesConsumed = useCallback((articleUrls, shouldRemove) => {
+  const markDigestArticlesConsumed = useCallback(async (urlsByDate, shouldRemove) => {
     const markedAt = new Date().toISOString()
-    updateDigestArticles(articleUrls, article => ({
+    await updateArticlesAcrossDates(urlsByDate, (article) => ({
       ...article,
       ...(shouldRemove
         ? reduceArticleLifecycle(article, { type: ArticleLifecycleEventType.MARK_REMOVED }).patch
@@ -113,7 +136,7 @@ export function useDigest(results) {
             markedAt,
           }).patch),
     }))
-  }, [updateDigestArticles])
+  }, [updateArticlesAcrossDates])
 
   const writeDigest = useCallback((digestPatch) => {
     setPayloadRef.current(current => {
@@ -170,6 +193,7 @@ export function useDigest(results) {
     if (!payload || payload.date !== pendingRequest.date) return
 
     const { articleDescriptors, requestToken } = pendingRequest
+    const urlsByDate = groupDescriptorsByDate(articleDescriptors, results?.payloads || [])
     const articleUrls = articleDescriptors.map(d => d.url)
     const controller = new AbortController()
     abortControllerRef.current = controller
@@ -178,7 +202,7 @@ export function useDigest(results) {
     const runDigest = async () => {
       let previousSummaryByUrl
       try {
-        previousSummaryByUrl = markDigestArticlesLoading(articleUrls)
+        previousSummaryByUrl = await markDigestArticlesLoading(urlsByDate)
 
         writeDigest({ errorMessage: null })
 
@@ -194,7 +218,7 @@ export function useDigest(results) {
         if (requestTokenRef.current !== requestToken) return
 
         if (result.success) {
-          restoreDigestArticlesSummary(articleUrls, previousSummaryByUrl)
+          await restoreDigestArticlesSummary(urlsByDate, previousSummaryByUrl)
           writeDigest({
             status: summaryDataReducer.SummaryDataStatus.AVAILABLE,
             markdown: result.digest_markdown,
@@ -214,10 +238,10 @@ export function useDigest(results) {
         })
       } catch (error) {
         if (error.name === 'AbortError') {
-          restoreDigestArticlesSummary(articleUrls, previousSummaryByUrl)
+          await restoreDigestArticlesSummary(urlsByDate, previousSummaryByUrl)
           return
         }
-        restoreDigestArticlesSummary(articleUrls, previousSummaryByUrl)
+        await restoreDigestArticlesSummary(urlsByDate, previousSummaryByUrl)
         writeDigest({
           status: summaryDataReducer.SummaryDataStatus.ERROR,
           errorMessage: error.message,
@@ -231,7 +255,7 @@ export function useDigest(results) {
     }
 
     void runDigest()
-  }, [pendingRequest, payload, targetDate, clearSelection, expand, markDigestArticlesLoading, restoreDigestArticlesSummary, writeDigest])
+  }, [pendingRequest, payload, targetDate, clearSelection, expand, markDigestArticlesLoading, restoreDigestArticlesSummary, writeDigest, results?.payloads])
 
   useEffect(() => {
     if (status !== summaryDataReducer.SummaryDataStatus.LOADING) return
@@ -241,14 +265,18 @@ export function useDigest(results) {
     })
   }, [status, writeDigest])
 
-  const collapse = useCallback((shouldRemove = false) => {
+  const collapse = useCallback(async (shouldRemove = false) => {
     if (status === summaryDataReducer.SummaryDataStatus.AVAILABLE && data?.articleUrls?.length > 0) {
-      markDigestArticlesConsumed(data.articleUrls, shouldRemove)
+      const urlsByDate = groupDescriptorsByDate(
+        data.articleUrls.map((url) => ({ url })),
+        results?.payloads || []
+      )
+      await markDigestArticlesConsumed(urlsByDate, shouldRemove)
     }
     logTransition('digest-view', DIGEST_LOCK_OWNER, 'expanded', 'collapsed')
     releaseZenLock(DIGEST_LOCK_OWNER)
     setExpanded(false)
-  }, [status, data, markDigestArticlesConsumed])
+  }, [status, data, markDigestArticlesConsumed, results?.payloads])
 
   useEffect(() => {
     return () => {

--- a/client/src/hooks/useDigest.js
+++ b/client/src/hooks/useDigest.js
@@ -31,7 +31,8 @@ export function useDigest(results) {
   const latestPayloadDate = results?.payloads
     ? [...results.payloads].sort((a, b) => b.date.localeCompare(a.date))[0]?.date
     : null
-  const storageKey = getNewsletterScrapeKey(targetDate ?? latestPayloadDate ?? '0000-00-00')
+  const activeDate = targetDate ?? latestPayloadDate ?? '0000-00-00'
+  const storageKey = getNewsletterScrapeKey(activeDate)
   const [payload] = useSupabaseStorage(storageKey, null)
 
   const activePayload = payload
@@ -138,8 +139,8 @@ export function useDigest(results) {
     }))
   }, [updateArticlesAcrossDates])
 
-  const writeDigest = useCallback(async (digestPatch) => {
-    await setStorageValueAsync(storageKey, (current) => {
+  const writeDigest = useCallback(async (digestPatch, targetStorageKey = storageKey) => {
+    await setStorageValueAsync(targetStorageKey, (current) => {
       if (!current) return current
       const fromStatus = summaryDataReducer.getSummaryDataStatus(current.digest)
       const toStatus = digestPatch.status
@@ -148,7 +149,7 @@ export function useDigest(results) {
       }
       return { ...current, digest: { ...(current.digest || {}), ...digestPatch } }
     })
-  }, [storageKey])
+  }, [])
 
   const createRequestToken = () => `${Date.now()}-${Math.random().toString(16).slice(2)}`
 
@@ -204,7 +205,7 @@ export function useDigest(results) {
       try {
         previousSummaryByUrl = await markDigestArticlesLoading(urlsByDate)
 
-        await writeDigest({ errorMessage: null })
+        await writeDigest({ errorMessage: null }, getNewsletterScrapeKey(pendingRequest.date))
 
         const response = await window.fetch('/api/digest', {
           method: 'POST',
@@ -226,7 +227,7 @@ export function useDigest(results) {
             generatedAt: new Date().toISOString(),
             effort: 'low',
             errorMessage: null,
-          })
+          }, getNewsletterScrapeKey(pendingRequest.date))
           clearSelection()
           expand()
           return
@@ -235,7 +236,7 @@ export function useDigest(results) {
         await writeDigest({
           status: summaryDataReducer.SummaryDataStatus.ERROR,
           errorMessage: result.error,
-        })
+        }, getNewsletterScrapeKey(pendingRequest.date))
       } catch (error) {
         if (error.name === 'AbortError') {
           await restoreDigestArticlesSummary(urlsByDate, previousSummaryByUrl)
@@ -245,7 +246,7 @@ export function useDigest(results) {
         await writeDigest({
           status: summaryDataReducer.SummaryDataStatus.ERROR,
           errorMessage: error.message,
-        })
+        }, getNewsletterScrapeKey(pendingRequest.date))
       } finally {
         if (requestTokenRef.current === requestToken) {
           requestTokenRef.current = null
@@ -259,11 +260,12 @@ export function useDigest(results) {
 
   useEffect(() => {
     if (status !== summaryDataReducer.SummaryDataStatus.LOADING) return
+    if (!payload || payload.date !== activeDate) return
     void writeDigest({
       status: summaryDataReducer.SummaryDataStatus.UNKNOWN,
       errorMessage: null,
-    })
-  }, [status, writeDigest])
+    }, getNewsletterScrapeKey(payload.date))
+  }, [status, payload, activeDate, writeDigest])
 
   const collapse = useCallback(async (shouldRemove = false) => {
     try {

--- a/client/src/hooks/useDigest.js
+++ b/client/src/hooks/useDigest.js
@@ -32,9 +32,7 @@ export function useDigest(results) {
     ? [...results.payloads].sort((a, b) => b.date.localeCompare(a.date))[0]?.date
     : null
   const storageKey = getNewsletterScrapeKey(targetDate ?? latestPayloadDate ?? '0000-00-00')
-  const [payload, setPayload] = useSupabaseStorage(storageKey, null)
-  const setPayloadRef = useRef(null)
-  setPayloadRef.current = setPayload
+  const [payload] = useSupabaseStorage(storageKey, null)
 
   const activePayload = payload
 
@@ -140,8 +138,8 @@ export function useDigest(results) {
     }))
   }, [updateArticlesAcrossDates])
 
-  const writeDigest = useCallback((digestPatch) => {
-    setPayloadRef.current(current => {
+  const writeDigest = useCallback(async (digestPatch) => {
+    await setStorageValueAsync(storageKey, (current) => {
       if (!current) return current
       const fromStatus = summaryDataReducer.getSummaryDataStatus(current.digest)
       const toStatus = digestPatch.status
@@ -150,7 +148,7 @@ export function useDigest(results) {
       }
       return { ...current, digest: { ...(current.digest || {}), ...digestPatch } }
     })
-  }, [])
+  }, [storageKey])
 
   const createRequestToken = () => `${Date.now()}-${Math.random().toString(16).slice(2)}`
 
@@ -206,7 +204,7 @@ export function useDigest(results) {
       try {
         previousSummaryByUrl = await markDigestArticlesLoading(urlsByDate)
 
-        writeDigest({ errorMessage: null })
+        await writeDigest({ errorMessage: null })
 
         const response = await window.fetch('/api/digest', {
           method: 'POST',
@@ -221,7 +219,7 @@ export function useDigest(results) {
 
         if (result.success) {
           await restoreDigestArticlesSummary(urlsByDate, previousSummaryByUrl)
-          writeDigest({
+          await writeDigest({
             status: summaryDataReducer.SummaryDataStatus.AVAILABLE,
             markdown: result.digest_markdown,
             articleUrls: result.included_urls ?? articleUrls,
@@ -234,7 +232,7 @@ export function useDigest(results) {
           return
         }
 
-        writeDigest({
+        await writeDigest({
           status: summaryDataReducer.SummaryDataStatus.ERROR,
           errorMessage: result.error,
         })
@@ -244,7 +242,7 @@ export function useDigest(results) {
           return
         }
         await restoreDigestArticlesSummary(urlsByDate, previousSummaryByUrl)
-        writeDigest({
+        await writeDigest({
           status: summaryDataReducer.SummaryDataStatus.ERROR,
           errorMessage: error.message,
         })
@@ -261,7 +259,7 @@ export function useDigest(results) {
 
   useEffect(() => {
     if (status !== summaryDataReducer.SummaryDataStatus.LOADING) return
-    writeDigest({
+    void writeDigest({
       status: summaryDataReducer.SummaryDataStatus.UNKNOWN,
       errorMessage: null,
     })

--- a/client/src/hooks/useSupabaseStorage.js
+++ b/client/src/hooks/useSupabaseStorage.js
@@ -132,6 +132,31 @@ async function writeValue(key, value) {
   }
 }
 
+export function getCachedStorageValue(key) {
+  return readCache.get(key)
+}
+
+export function subscribeToStorageKey(key, listener) {
+  return subscribe(key, listener)
+}
+
+export async function setStorageValueAsync(key, nextValue, defaultValue = null) {
+  const previous = await readValue(key, defaultValue)
+  const resolved = typeof nextValue === 'function' ? nextValue(previous) : nextValue
+  if (resolved === previous) return
+
+  readCache.set(key, resolved)
+  emitChange(key)
+
+  try {
+    await writeValue(key, resolved)
+  } catch (error) {
+    readCache.set(key, previous)
+    emitChange(key)
+    throw error
+  }
+}
+
 export function useSupabaseStorage(key, defaultValue) {
   // ─────────────────────────────────────────────────────────────────────────────
   // Cache Seeding for Scrape-First Hydration

--- a/client/src/lib/articleActionBus.js
+++ b/client/src/lib/articleActionBus.js
@@ -1,0 +1,29 @@
+const subscribersByUrl = new Map()
+
+function getSubscribers(url) {
+  if (!subscribersByUrl.has(url)) {
+    subscribersByUrl.set(url, new Set())
+  }
+  return subscribersByUrl.get(url)
+}
+
+export function subscribeToArticleAction(url, callback) {
+  const subscribers = getSubscribers(url)
+  subscribers.add(callback)
+  return () => {
+    subscribers.delete(callback)
+    if (subscribers.size === 0) {
+      subscribersByUrl.delete(url)
+    }
+  }
+}
+
+export function publishArticleAction(urls, action) {
+  for (const url of urls) {
+    const subscribers = subscribersByUrl.get(url)
+    if (!subscribers) continue
+    for (const callback of subscribers) {
+      callback(action)
+    }
+  }
+}

--- a/thoughts/26-04-03-selection-dock-state-machine/plan.md
+++ b/thoughts/26-04-03-selection-dock-state-machine/plan.md
@@ -1,0 +1,107 @@
+---
+last_updated: 2026-04-03 20:40
+---
+# Plan: Selection dock action state machine + shared summary/digest sensitivity
+
+## Scope map
+
+Primary client files expected to change:
+- `client/src/App.jsx`
+- `client/src/components/SelectionActionDock.jsx`
+- `client/src/components/ArticleCard.jsx`
+- `client/src/hooks/useDigest.js`
+- `client/src/hooks/useSupabaseStorage.js`
+- potentially `client/src/index.css`
+
+## Updated constraints from review
+
+1. Dock state cannot rely on `results.payloads` because live state is in storage-backed caches/hooks.
+2. Dock cannot open summary by instantiating a second `useSummary` instance. Overlay is rendered by `ArticleCard` instance only.
+3. Batch operations should avoid per-article concurrent hook writes against the same date payload.
+4. Digest’s current single-date mutation behavior must be aligned if dock depends on digest-driven summary status.
+
+## Implementation strategy
+
+### 1) Add shared article action event bus (single source for dock -> cards)
+
+Introduce a lightweight module-level bus for article actions:
+- `open-summary` for url
+- `fetch-summary` for url / urls
+
+`ArticleCard` subscribes (by url) and routes events into its existing `useSummary` instance:
+- `open-summary` => `summary.expand()`
+- `fetch-summary` => invoke fetch only if actionable (unknown/error), ignore loading/available
+
+This preserves current overlay ownership and summary state machine while allowing dock actions to drive card-owned summary behavior.
+
+### 2) Make dock state derive from live storage, not stale `results`
+
+In `App.jsx`, add a hook that computes selected-article view model from current cache values:
+- use selected IDs from `useInteraction`
+- read the live payload(s) for dates in current results via a shared storage snapshot helper in `useSupabaseStorage`
+- resolve selected articles from that snapshot each render
+
+Derived facts:
+- selected count
+- single selected article (if one)
+- single summary status
+- summarize-each actionable count (`unknown` + `error` only)
+- all summaries available (for selected)
+- any summaries loading
+
+### 3) Redesign `SelectionActionDock` as declarative action list
+
+Replace fixed buttons with condition-driven action entries.
+
+Always:
+- Deselect
+- Read
+- Remove
+
+Single select:
+- Summarize/Open (label/icon swap to Open when status=available)
+- Browse
+
+Multi select:
+- Digest
+- Summarize Each (disabled when none actionable; visually inactive when all selected have summaries)
+
+Also handle loading/error labels where relevant.
+
+### 4) Implement batch read/remove as per-date grouped writes
+
+In `App.jsx` orchestration, group selected articles by `issueDate`, and perform one payload update per date using `useSupabaseStorage` set function per date.
+
+Do not loop through per-article `useArticleState()` instances.
+
+### 5) Align digest side-effects for multi-date selections
+
+Update `useDigest` so digest lifecycle mutations (`summary.loading`, restore, consumed mark read/remove) apply across all selected dates, not just target date.
+
+Approach:
+- resolve all involved dates from selected descriptors
+- for each date payload key, apply grouped article URL updates
+- keep digest artifact stored under target date as today
+
+This guarantees dock summary sensitivity to digest-driven transitions across selected items.
+
+### 6) Browse/open behavior details
+
+- Browse: single selected article URL opens in new tab.
+- Open: dispatch shared `open-summary` event for selected URL.
+- If zen lock is occupied, existing behavior no-ops naturally.
+
+### 7) Verification
+
+- `cd client && npm run build`
+- manual run:
+  - select 1 unknown => Summarize -> loading -> Open
+  - select 1 available => Open immediately
+  - select N mixed statuses => Summarize Each active only for unknown/error
+  - select N all available => Summarize Each inactive
+  - digest with multi-date selection updates statuses and dock conditions
+  - read/remove batch actions apply across selected dates
+
+### 8) Screenshot
+
+Take updated screenshot of dock states (single + multi selection) if browser screenshot tooling is available.

--- a/thoughts/26-04-03-selection-dock-state-machine/plan.review.md
+++ b/thoughts/26-04-03-selection-dock-state-machine/plan.review.md
@@ -1,0 +1,54 @@
+---
+last_updated: 2026-04-03 20:40
+---
+# Plan Review: Selection Dock State Machine + Summary-Aware Buttons
+
+**Plan**: `thoughts/26-04-03-selection-dock-state-machine/plan.md`  
+**Status**: Request Changes  
+**Reviewed against**: current `work` branch after `6ea59f2` (`feat(client): integrate digest lifecycle with article state transitions`) and `5ffa6d3` (`feat(client): move multi-selection actions to iOS-style bottom dock`)
+
+## Critical Issues (Must Fix)
+
+- [ ] **State ownership**: I recommend not deriving the dock state machine from `results.payloads` in `App.jsx`.
+  - *Why*: `AppContent` currently reads selection descriptors from `results?.payloads` in `client/src/App.jsx:35-55`, but those payloads stop being authoritative after mount. Live article state flows through `useSupabaseStorage` inside `CalendarDay` (`client/src/components/CalendarDay.jsx:51-63`) and then through `useArticleState` / `useSummary`. `mergeIntoCache()` also mutates the shared cache without updating `results` (`client/src/hooks/useSupabaseStorage.js:251-256`). A dock derived from `results` will drift on `read`, `removed`, and especially `summary.status`.
+  - *Suggestion*: derive dock availability from live storage-backed data, not from `results`. A dock-specific hook that subscribes to the relevant daily payloads would be safer than centralizing this in `App.jsx`.
+
+- [ ] **Secondary `useSummary()` instances will not open the real summary overlay**: I recommend rethinking the proposed `SelectionActionController`.
+  - *Why*: `useSummary()` owns its own local `expanded` state (`client/src/hooks/useSummary.js:28-34,188-193`), but the actual `ZenModeOverlay` is rendered only inside `ArticleCard` when that specific hook instance has `summary.expanded === true` (`client/src/components/ArticleCard.jsx:229-230,353-366`). Calling `summary.expand()` from a controller instance will not open the existing card overlay. The same problem applies to the summary-ready toast path: `emitToast({ onOpen: expand })` binds the toast to the hook instance that fetched the summary (`client/src/hooks/useSummary.js:123-130`), and `ToastContainer` simply calls that callback (`client/src/components/ToastContainer.jsx:21-24`).
+  - *Suggestion*: keep the persisted summary data shared, but introduce a separate shared “open summary by URL” mechanism if the dock must open overlays. I would avoid duplicating `useSummary()` instances as the control surface.
+
+- [ ] **Batching through per-article hooks is riskier than the plan assumes**: I recommend not implementing batch read/remove/summarize-each as “loop over N selected `useArticleState()` / `useSummary()` instances”.
+  - *Why*: `useArticleState.updateArticle()` writes the entire daily payload via `setPayload(current => ...)` (`client/src/hooks/useArticleState.js:20-33`), and `useSummary()` does the same through `updateArticle()` (`client/src/hooks/useSummary.js:58-80`). In `useSupabaseStorage`, each hook instance resolves updater functions against its own `valueRef.current` (`client/src/hooks/useSupabaseStorage.js:214-239`). If several selected articles share the same `issueDate`, N sibling hook instances can resolve against stale per-instance state and overwrite each other.
+  - *Suggestion*: group selected articles by `issueDate` and perform one payload write per date, or serialize writes per date. `useDigest` already uses the safer pattern: one `setPayload()` call updates all matching articles in the active payload (`client/src/hooks/useDigest.js:60-116`).
+
+- [ ] **The plan assumes a stronger digest coupling than the code currently has**: I recommend explicitly accounting for multi-date selection before depending on digest-induced summary states.
+  - *Why*: `useDigest` binds itself to a single `targetDate` storage key (`client/src/hooks/useDigest.js:14-19,31-35,146-157`). Its side effects only traverse `current.articles` in that one payload (`client/src/hooks/useDigest.js:60-116`). So a digest over articles from multiple dates does not mark every selected article `summary.loading`, and later does not mark every selected article read/removed on collapse. This may already be a latent bug, but it becomes load-bearing for your dock plan because the plan explicitly wants summarize buttons to react to digest-driven summary transitions.
+  - *Suggestion*: either constrain the new dock behavior to same-date selections, or fix cross-date digest side effects first so the dock is not built on top of an incomplete source of truth.
+
+- [ ] **The summarize action matrix is still underspecified for `loading` and `error`**: I recommend tightening this before implementation.
+  - *Why*: the plan says single-select summarize should disable while loading, but multi-select “summarize each” only skips `available`. In the actual hook, any non-available state falls through to `fetchSummary()` (`client/src/hooks/useSummary.js:168-178`), and `fetchSummary()` will abort/restart the current request for that hook instance (`client/src/hooks/useSummary.js:84-105`). For the dock, `loading` needs to be treated as inactive/no-op, and `error` likely needs to be treated as retryable.
+  - *Suggestion*: define an explicit `actionableForSummarizeEach` set. I would make it `unknown` + `error`, while `loading` is skipped and `available` is complete.
+
+## Suggestions (Optional)
+
+- [ ] Consider keeping `SelectionActionDock.jsx` dumb and feeding it a declarative action list with stable IDs. That will make button animation, keying, and single-vs-multi transitions easier to reason about than branching ad hoc in `App.jsx`.
+
+- [ ] Consider a stronger mobile layout plan before implementation. The current dock is a single `max-w-md` row with `min-w-20` buttons (`client/src/components/SelectionActionDock.jsx:3-15`), and the feed only budgets `pb-24` below the content (`client/src/components/Feed.jsx:3-9`). Five actions in single-select mode will be cramped on small screens unless you intentionally redesign the dock hierarchy.
+
+- [ ] Consider extracting the “openable URL” normalization from `ArticleCard` (`client/src/components/ArticleCard.jsx:248-260`) instead of reimplementing it in the dock for `Browse`.
+
+## Blindspot Check
+
+- [ ] What should `Open` do if the digest overlay already owns the zen lock? Today `expand()` simply no-ops when `acquireZenLock()` fails (`client/src/hooks/useSummary.js:14-25,188-193`).
+
+- [ ] What should happen to selection after single-item `Browse` or `Open`? The plan defines clearing after batch read/remove, but not after the single-item actions.
+
+- [ ] How should `Summarize Each` look when the selection is mixed: some `available`, some `loading`, some `error`, some `unknown`?
+
+- [ ] Do you want equal visual weight for all actions? With five buttons, I would expect at least one stronger primary action and one clearly destructive action, otherwise the dock will get visually noisy quickly.
+
+## Codebase Reality Check
+
+- `results.payloads` in `App.jsx` are not the live article-state source after initial render; `CalendarDay` and all per-article hooks read from `useSupabaseStorage`.
+- `useSummary.expand()` only affects the hook instance that owns it; the rendered summary overlay still lives in `ArticleCard`.
+- `useDigest` currently mutates only the most recent selected date's payload, not every selected article across dates.


### PR DESCRIPTION
### Motivation
- Prevent a race where digest completion writes could overwrite restored per-article summary state by resolving against stale hook-local payload state.
- Make the selection dock's summarize action visuals consistent between single- and multi-select modes.

### Description
- Change `useDigest.writeDigest` to perform digest metadata writes via the shared async storage API by calling `setStorageValueAsync(storageKey, ...)` so updates compose on the latest cache value. Calls to this writer are now `await`ed at digest lifecycle points to avoid ordering races. (file: `client/src/hooks/useDigest.js`)
- Remove the prior hook-local setter usage (no more `setPayloadRef.current(...)`) and read payload via `useSupabaseStorage(storageKey)` without attempting local-set composition. (file: `client/src/hooks/useDigest.js`)
- Align the `Summarize Each` action icon with the single-article `Summarize` action by using the same sparkles icon to keep UI consistent. (file: `client/src/components/SelectionActionDock.jsx`)
- Kept existing digest behavior (status resets, restore logic, and article-state persistence) but routed the digest metadata writes through the safe storage write path.

### Testing
- Performed dependency install with `cd client && npm install`, which completed successfully. (success)
- Built the frontend with `cd client && npm run build` (Vite production build), which completed successfully. (success)
- No additional automated unit tests were run as part of this change; the modification was validated by a successful build and local code inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0a81345a48332b99eb542089e971c)