### PR TITLE
Add multi-model Consensus feature (backend orchestration, API, CLI and hidden React UI)

### DIFF
--- a/.agents/skills/consensus/SKILL.md
+++ b/.agents/skills/consensus/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: consensus
+description: Run a no-web-server multi-model consensus loop (Claude + GPT + Gemini) for a prompt and use the converged answer in your response.
+argument-hint: [question]
+last_updated: 2026-04-08 07:16
+---
+# Consensus skill
+
+Use this skill when the user asks you to arbitrate an answer across multiple models.
+
+## What this does
+
+- Runs a round-based consensus loop between Claude, GPT, and Gemini.
+- Stops early when any model emits a `<conclusion>...</conclusion>` final answer.
+- Otherwise returns a no-consensus fallback with each model's last response.
+
+## Requirements
+
+Set these environment variables:
+
+- `ANTHROPIC_API_KEY`
+- `OPENAI_API_KEY`
+- `GEMINI_API_KEY`
+
+Optional model overrides:
+
+- `ANTHROPIC_MODEL`
+- `OPENAI_MODEL`
+- `GEMINI_MODEL`
+
+## Run
+
+```bash
+uv run .agents/skills/consensus/scripts/run_consensus.py \
+  "<question>" --thinking low --max-turns 4 --json
+```
+
+Use `--thinking high` for more expensive deeper reasoning.
+
+## Agent workflow
+
+1. Execute the script with the user's exact prompt.
+2. Read the JSON output.
+3. Use `answer` as the primary response, and mention if `reached_consensus` is false.

--- a/.agents/skills/consensus/scripts/run_consensus.py
+++ b/.agents/skills/consensus/scripts/run_consensus.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Run a multi-model consensus roundtrip for a single user question."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+
+import consensus
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("question", type=str, help="The user prompt to evaluate")
+    parser.add_argument("--max-turns", type=int, default=consensus.DEFAULT_MAX_TURNS)
+    parser.add_argument("--thinking", choices=["low", "high"], default="low")
+    parser.add_argument("--json", action="store_true", dest="json_output")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = consensus.load_config(thinking=args.thinking, max_turns=args.max_turns)
+    result = consensus.run_question(args.question, config)
+
+    if args.json_output:
+        print(json.dumps(dataclasses.asdict(result), indent=2))
+        return
+
+    print("=== Consensus answer ===")
+    print(result.answer)
+    print("\n=== Metadata ===")
+    print(f"reached_consensus: {result.reached_consensus}")
+    print(f"stop_reason: {result.stop_reason}")
+    print(f"rounds: {len(result.rounds)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/consensus/scripts/run_consensus.py
+++ b/.agents/skills/consensus/scripts/run_consensus.py
@@ -6,6 +6,12 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import json
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 import consensus
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -396,9 +396,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -416,9 +413,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -436,9 +430,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -456,9 +447,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [

--- a/client/src/consensus/ConsensusApp.jsx
+++ b/client/src/consensus/ConsensusApp.jsx
@@ -1,0 +1,190 @@
+import { ChevronDown, ChevronUp, Radar, Send, Sparkles } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import './consensus.css'
+
+const MODEL_LABELS = {
+  claude: 'Claude',
+  gpt: 'GPT',
+  gemini: 'Gemini',
+}
+
+const STARTER_PROMPTS = [
+  'Compare Python and Go for backend APIs in 2026 and recommend one for a small team.',
+  'Give me the most practical strategy for staying technically sharp while leading engineering managers.',
+  'Should I optimize for speed or maintainability in a one-person product? Give a nuanced recommendation.'
+]
+
+function MessageBubble({ message }) {
+  return (
+    <div className={`consensus-message consensus-message-${message.role}`}>
+      <div className="consensus-message-meta">{message.role === 'user' ? 'You' : 'Consensus'}</div>
+      <div className="consensus-message-body">{message.content}</div>
+    </div>
+  )
+}
+
+function TracePanel({ rounds, reachedConsensus, stopReason, expanded, onToggle }) {
+  const statusLabel = reachedConsensus == null
+    ? 'No run yet'
+    : reachedConsensus
+      ? 'Consensus reached'
+      : 'Stopped without consensus'
+  const lastTurn = rounds.at(-1)?.turn
+
+  return (
+    <aside className="consensus-trace">
+      <div className="consensus-trace-header">
+        <div className="consensus-eyebrow"><Radar size={14} /> Debate trace</div>
+        <button type="button" className="consensus-toggle" onClick={onToggle}>
+          {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+          {expanded ? 'Hide' : 'Show'}
+        </button>
+      </div>
+
+      <div className="consensus-trace-status">
+        <span className={`consensus-pill ${reachedConsensus ? 'is-ok' : ''}`}>{statusLabel}</span>
+        {stopReason ? <span className="consensus-subtle">Stop: {stopReason}</span> : null}
+      </div>
+
+      {expanded ? (
+        rounds.length > 0 ? (
+          <div className="consensus-rounds">
+            {rounds.map((round) => (
+              <details key={round.turn} className="consensus-round" open={round.turn === lastTurn}>
+                <summary>Round {round.turn}</summary>
+                {Object.entries(round.responses).map(([modelName, response]) => (
+                  <div key={modelName} className="consensus-response">
+                    <h4>{MODEL_LABELS[modelName] || modelName}</h4>
+                    <pre>{response}</pre>
+                  </div>
+                ))}
+              </details>
+            ))}
+          </div>
+        ) : (
+          <div className="consensus-empty-trace">
+            <Sparkles size={16} />
+            Run a prompt and inspect the hidden model debate.
+          </div>
+        )
+      ) : (
+        <p className="consensus-subtle">Open to inspect each internal model round.</p>
+      )}
+    </aside>
+  )
+}
+
+export default function ConsensusApp() {
+  const [messages, setMessages] = useState([])
+  const [nextMessageId, setNextMessageId] = useState(1)
+  const [inputValue, setInputValue] = useState('')
+  const [isRunning, setIsRunning] = useState(false)
+  const [rounds, setRounds] = useState([])
+  const [reachedConsensus, setReachedConsensus] = useState(null)
+  const [stopReason, setStopReason] = useState(null)
+  const [traceExpanded, setTraceExpanded] = useState(true)
+
+  const canSend = useMemo(() => inputValue.trim().length > 0 && !isRunning, [inputValue, isRunning])
+
+  async function runConsensus(promptText) {
+    const userMessage = { id: nextMessageId, role: 'user', content: promptText }
+    const nextMessages = [...messages, userMessage]
+    setMessages(nextMessages)
+    setNextMessageId((value) => value + 1)
+    setInputValue('')
+    setIsRunning(true)
+
+    try {
+      const response = await fetch('/api/consensus/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: nextMessages.map(({ role, content }) => ({ role, content })) })
+      })
+      const payload = await response.json()
+      if (!response.ok || !payload.success) {
+        throw new Error(payload.error || `HTTP ${response.status}`)
+      }
+
+      const result = payload.result
+      setRounds(result.rounds || [])
+      setReachedConsensus(result.reached_consensus)
+      setStopReason(result.stop_reason)
+      setTraceExpanded(true)
+      setMessages((current) => [...current, { id: nextMessageId + 1, role: 'assistant', content: result.answer }])
+      setNextMessageId((value) => value + 1)
+    } catch (error) {
+      setRounds([])
+      setReachedConsensus(false)
+      setStopReason('max_turns')
+      setTraceExpanded(true)
+      setMessages((current) => [...current, { id: nextMessageId + 1, role: 'assistant', content: `Consensus failed: ${error.message}` }])
+      setNextMessageId((value) => value + 1)
+    } finally {
+      setIsRunning(false)
+    }
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault()
+    if (!canSend) return
+    runConsensus(inputValue.trim())
+  }
+
+  return (
+    <div className="consensus-root">
+      <div className="consensus-shell">
+        <header className="consensus-topbar">
+          <div>
+            <p className="consensus-kicker">Hidden utility</p>
+            <h1>Consensus</h1>
+            <p className="consensus-subtitle">Three models debate quietly. You get one clean answer.</p>
+          </div>
+        </header>
+
+        <main className="consensus-grid">
+          <section className="consensus-chat">
+            {messages.length === 0 ? (
+              <div className="consensus-empty">
+                <h2>Start with a strong prompt</h2>
+                <p>Pick a starter or write your own. The debate trace stays separate on the right.</p>
+                <div className="consensus-starters">
+                  {STARTER_PROMPTS.map((prompt) => (
+                    <button key={prompt} type="button" className="consensus-starter" onClick={() => runConsensus(prompt)}>
+                      {prompt}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="consensus-thread">
+                {messages.map((message) => <MessageBubble key={message.id} message={message} />)}
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="consensus-composer">
+              <textarea
+                value={inputValue}
+                onChange={(event) => setInputValue(event.target.value)}
+                placeholder="Ask anything. Consensus runs on submit."
+                rows={3}
+                disabled={isRunning}
+              />
+              <button type="submit" disabled={!canSend}>
+                <Send size={16} />
+                {isRunning ? 'Running...' : 'Run consensus'}
+              </button>
+            </form>
+          </section>
+
+          <TracePanel
+            rounds={rounds}
+            reachedConsensus={reachedConsensus}
+            stopReason={stopReason}
+            expanded={traceExpanded}
+            onToggle={() => setTraceExpanded((open) => !open)}
+          />
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/client/src/consensus/consensus.css
+++ b/client/src/consensus/consensus.css
@@ -1,0 +1,302 @@
+.consensus-root {
+  min-height: 100dvh;
+  background: radial-gradient(circle at 12% 8%, #f9f3ea 0%, #f7f8fb 40%, #eef1f8 100%);
+  color: #18212f;
+  padding: 1rem;
+}
+
+.consensus-shell {
+  max-width: 1280px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1rem;
+}
+
+.consensus-topbar {
+  background: #ffffffd9;
+  border: 1px solid #d7dee9;
+  border-radius: 1.25rem;
+  padding: 1rem 1.25rem;
+  backdrop-filter: blur(8px);
+}
+
+.consensus-topbar h1 {
+  margin: 0;
+  font-size: clamp(1.7rem, 2.8vw, 2.25rem);
+  line-height: 1.1;
+}
+
+.consensus-kicker {
+  margin: 0 0 0.25rem;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #3e6498;
+  font-weight: 700;
+}
+
+.consensus-subtitle {
+  margin: 0.4rem 0 0;
+  color: #51637f;
+}
+
+.consensus-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(300px, 1fr);
+  gap: 1rem;
+}
+
+.consensus-chat,
+.consensus-trace {
+  background: #fffffff0;
+  border: 1px solid #d7dee9;
+  border-radius: 1.3rem;
+  box-shadow: 0 12px 26px #1f34561a;
+}
+
+.consensus-chat {
+  min-height: 68dvh;
+  display: grid;
+  grid-template-rows: 1fr auto;
+  overflow: hidden;
+}
+
+.consensus-thread,
+.consensus-empty {
+  padding: 1.2rem;
+  overflow-y: auto;
+  display: grid;
+  align-content: start;
+  gap: 0.85rem;
+}
+
+.consensus-empty h2,
+.consensus-empty p {
+  margin: 0;
+}
+
+.consensus-empty p {
+  color: #5b6880;
+  max-width: 62ch;
+}
+
+.consensus-starters {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.consensus-starter {
+  text-align: left;
+  border-radius: 0.9rem;
+  border: 1px solid #d3deed;
+  background: #fbfdff;
+  color: #203a62;
+  padding: 0.78rem 0.9rem;
+  cursor: pointer;
+}
+
+.consensus-starter:hover {
+  border-color: #7ea3d4;
+  background: #f1f6fe;
+}
+
+.consensus-message {
+  max-width: min(88%, 860px);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.consensus-message-user {
+  justify-self: end;
+}
+
+.consensus-message-assistant {
+  justify-self: start;
+}
+
+.consensus-message-meta {
+  font-size: 0.76rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: #5f6f86;
+}
+
+.consensus-message-body {
+  white-space: pre-wrap;
+  padding: 0.9rem 1rem;
+  border-radius: 1rem;
+  line-height: 1.5;
+}
+
+.consensus-message-user .consensus-message-body {
+  background: linear-gradient(135deg, #24456e, #335f93);
+  color: #f5f8ff;
+}
+
+.consensus-message-assistant .consensus-message-body {
+  background: #fffaf2;
+  border: 1px solid #eadfcf;
+}
+
+.consensus-composer {
+  border-top: 1px solid #d7dee9;
+  padding: 0.9rem;
+  display: grid;
+  gap: 0.65rem;
+  background: #fffffffa;
+}
+
+.consensus-composer textarea {
+  width: 100%;
+  border: 1px solid #c7d5e9;
+  border-radius: 0.9rem;
+  padding: 0.72rem 0.78rem;
+  resize: vertical;
+  min-height: 4.5rem;
+}
+
+.consensus-composer button {
+  justify-self: end;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  border: none;
+  border-radius: 999px;
+  background: #234d86;
+  color: white;
+  font-weight: 600;
+  padding: 0.56rem 0.95rem;
+  cursor: pointer;
+}
+
+.consensus-composer button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.consensus-trace {
+  padding: 0.95rem;
+  display: grid;
+  gap: 0.8rem;
+  align-content: start;
+}
+
+.consensus-trace-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.consensus-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: 1px solid #cfdaea;
+  border-radius: 999px;
+  padding: 0.36rem 0.65rem;
+  color: #48648b;
+  font-size: 0.79rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.consensus-toggle {
+  border: 1px solid #cfdaea;
+  background: #f7fbff;
+  color: #355a88;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.36rem 0.65rem;
+  cursor: pointer;
+}
+
+.consensus-trace-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
+}
+
+.consensus-pill {
+  display: inline-flex;
+  border-radius: 999px;
+  background: #f0ebde;
+  color: #69573b;
+  font-size: 0.77rem;
+  padding: 0.28rem 0.58rem;
+}
+
+.consensus-pill.is-ok {
+  background: #e7f3e9;
+  color: #2d6741;
+}
+
+.consensus-subtle {
+  color: #5f6f86;
+  font-size: 0.84rem;
+}
+
+.consensus-rounds {
+  display: grid;
+  gap: 0.56rem;
+  max-height: min(68dvh, 820px);
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.consensus-round {
+  border: 1px solid #dde5f0;
+  border-radius: 0.8rem;
+  padding: 0.6rem;
+  background: #fbfdff;
+}
+
+.consensus-round summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: #294b78;
+}
+
+.consensus-response h4 {
+  margin: 0.6rem 0 0.2rem;
+  color: #355a89;
+  font-size: 0.83rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.consensus-response pre {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  font-size: 0.8rem;
+  color: #1c2a40;
+  background: #f5f8fc;
+  border: 1px solid #dde5f0;
+  border-radius: 0.6rem;
+  padding: 0.55rem;
+}
+
+.consensus-empty-trace {
+  color: #4f607a;
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+@media (max-width: 980px) {
+  .consensus-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .consensus-chat {
+    min-height: 56dvh;
+  }
+
+  .consensus-starters {
+    grid-template-columns: 1fr;
+  }
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,12 +3,13 @@ import 'katex/dist/katex.min.css'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import ConsensusApp from './consensus/ConsensusApp'
 import { initQuakeConsole } from './lib/quakeConsole'
 
 initQuakeConsole()
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    {window.location.pathname === '/consensus' ? <ConsensusApp /> : <App />}
   </React.StrictMode>
 )

--- a/consensus.py
+++ b/consensus.py
@@ -142,13 +142,26 @@ async def ask_gpt(
     messages: list[dict[str, str]],
     config: ConsensusConfig,
 ) -> str:
-    response = await client.chat.completions.create(
+    try:
+        response = await client.chat.completions.create(
+            model=config.openai_model,
+            messages=[{"role": "developer", "content": system_prompt}] + messages,
+            reasoning_effort=config.thinking_level.openai_effort,
+            max_completion_tokens=16_000,
+        )
+        return response.choices[0].message.content or ""
+    except openai.BadRequestError as error:
+        if "messages" not in str(error):
+            raise
+
+    input_messages = [{"role": "developer", "content": system_prompt}] + messages
+    response = await client.responses.create(
         model=config.openai_model,
-        messages=[{"role": "developer", "content": system_prompt}] + messages,
-        reasoning_effort=config.thinking_level.openai_effort,
-        max_completion_tokens=16_000,
+        input=input_messages,
+        reasoning={"effort": config.thinking_level.openai_effort},
+        max_output_tokens=16_000,
     )
-    return response.choices[0].message.content or ""
+    return response.output_text
 
 
 async def ask_gemini(

--- a/consensus.py
+++ b/consensus.py
@@ -1,0 +1,241 @@
+"""Consensus orchestration shared by the hidden web feature and skill script."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import re
+from enum import StrEnum
+from typing import Literal
+
+import anthropic
+import openai
+from google import genai
+from google.genai import types
+
+import util
+
+MODEL_KEYS = ("claude", "gpt", "gemini")
+MODEL_NAMES = {
+    "claude": "Claude",
+    "gpt": "GPT",
+    "gemini": "Gemini",
+}
+DEFAULT_MAX_TURNS = 4
+CONCLUSION_REGEX = re.compile(r"<conclusion>(.*?)</conclusion>", re.DOTALL)
+SYSTEM_PROMPT = """\
+You are participating in a structured discussion with two other AI assistants.
+Each of you is a different model provider. Your name is {name}.
+
+Goal: produce the most truthful, useful final answer for the user.
+- Be concise and specific.
+- Critically evaluate other responses.
+- Agree when agreement is warranted.
+- Disagree clearly when needed.
+
+If true convergence is reached, wrap the final user-facing answer in
+<conclusion>...</conclusion>.
+Only emit <conclusion> when consensus is real.
+"""
+
+
+class ThinkingLevel(StrEnum):
+    LOW = "low"
+    HIGH = "high"
+
+    @property
+    def openai_effort(self) -> str:
+        return "xhigh" if self is ThinkingLevel.HIGH else "low"
+
+    @property
+    def anthropic_effort(self) -> str:
+        return self.value
+
+    @property
+    def gemini_level(self) -> str:
+        return self.value
+
+
+@dataclasses.dataclass(frozen=True)
+class ChatMessage:
+    role: Literal["user", "assistant"]
+    content: str
+
+
+@dataclasses.dataclass(frozen=True)
+class ConsensusConfig:
+    anthropic_model: str
+    openai_model: str
+    gemini_model: str
+    thinking_level: ThinkingLevel
+    max_turns: int
+
+
+@dataclasses.dataclass(frozen=True)
+class RoundResult:
+    turn: int
+    responses: dict[str, str]
+
+
+@dataclasses.dataclass(frozen=True)
+class ConsensusResult:
+    answer: str
+    reached_consensus: bool
+    stop_reason: Literal["consensus", "max_turns"]
+    rounds: list[RoundResult]
+
+
+def load_config(*, thinking: str = "low", max_turns: int = DEFAULT_MAX_TURNS) -> ConsensusConfig:
+    return ConsensusConfig(
+        anthropic_model=util.resolve_env_var("ANTHROPIC_MODEL", "claude-haiku-4-5-20251001"),
+        openai_model=util.resolve_env_var("OPENAI_MODEL", "gpt-5.4-mini"),
+        gemini_model=util.resolve_env_var("GEMINI_MODEL", "gemini-3-flash-preview"),
+        thinking_level=ThinkingLevel(thinking),
+        max_turns=max_turns,
+    )
+
+
+def build_system_prompt(name: str) -> str:
+    return SYSTEM_PROMPT.format(name=name)
+
+
+def extract_conclusion(responses: dict[str, str]) -> str | None:
+    for key in MODEL_KEYS:
+        match = CONCLUSION_REGEX.search(responses[key])
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def format_round_summary(responses: dict[str, str]) -> str:
+    return "\n\n---\n\n".join(
+        f"[{MODEL_NAMES[key]}]:\n{responses[key]}" for key in MODEL_KEYS
+    )
+
+
+async def ask_claude(
+    client: anthropic.AsyncAnthropic,
+    system_prompt: str,
+    messages: list[dict[str, str]],
+    config: ConsensusConfig,
+) -> str:
+    request_kwargs: dict[str, object] = {
+        "model": config.anthropic_model,
+        "system": system_prompt,
+        "messages": messages,
+        "max_tokens": 16_000,
+    }
+    if config.thinking_level is ThinkingLevel.HIGH:
+        request_kwargs["thinking"] = {"type": "adaptive"}
+        request_kwargs["output_config"] = {"effort": config.thinking_level.anthropic_effort}
+
+    response = await client.messages.create(**request_kwargs)
+    for block in response.content:
+        if block.type == "text":
+            return block.text
+    return response.content[0].text
+
+
+async def ask_gpt(
+    client: openai.AsyncOpenAI,
+    system_prompt: str,
+    messages: list[dict[str, str]],
+    config: ConsensusConfig,
+) -> str:
+    response = await client.chat.completions.create(
+        model=config.openai_model,
+        messages=[{"role": "developer", "content": system_prompt}] + messages,
+        reasoning_effort=config.thinking_level.openai_effort,
+        max_completion_tokens=16_000,
+    )
+    return response.choices[0].message.content or ""
+
+
+async def ask_gemini(
+    client: genai.Client,
+    system_prompt: str,
+    messages: list[dict[str, str]],
+    config: ConsensusConfig,
+) -> str:
+    contents: list[types.Content] = []
+    for message in messages:
+        role = "user" if message["role"] == "user" else "model"
+        contents.append(
+            types.Content(
+                role=role,
+                parts=[types.Part.from_text(text=message["content"])],
+            )
+        )
+
+    response = await client.aio.models.generate_content(
+        model=config.gemini_model,
+        contents=contents,
+        config=types.GenerateContentConfig(
+            system_instruction=system_prompt,
+            thinking_config=types.ThinkingConfig(
+                thinking_level=config.thinking_level.gemini_level
+            ),
+        ),
+    )
+    return response.text
+
+
+async def run_chat(messages: list[ChatMessage], config: ConsensusConfig) -> ConsensusResult:
+    if not messages:
+        raise ValueError("At least one message is required.")
+    if messages[-1].role != "user":
+        raise ValueError("The last message must be a user message.")
+
+    histories = {
+        key: [{"role": message.role, "content": message.content} for message in messages]
+        for key in MODEL_KEYS
+    }
+    systems = {key: build_system_prompt(MODEL_NAMES[key]) for key in MODEL_KEYS}
+    anthropic_client = anthropic.AsyncAnthropic(api_key=util.resolve_env_var("ANTHROPIC_API_KEY"))
+    openai_client = openai.AsyncOpenAI(api_key=util.resolve_env_var("OPENAI_API_KEY"))
+    gemini_client = genai.Client(api_key=util.resolve_env_var("GEMINI_API_KEY"))
+    rounds: list[RoundResult] = []
+    responses = {key: "" for key in MODEL_KEYS}
+
+    for turn in range(1, config.max_turns + 1):
+        results = await asyncio.gather(
+            ask_claude(anthropic_client, systems["claude"], histories["claude"], config),
+            ask_gpt(openai_client, systems["gpt"], histories["gpt"], config),
+            ask_gemini(gemini_client, systems["gemini"], histories["gemini"], config),
+            return_exceptions=True,
+        )
+
+        for key, result in zip(MODEL_KEYS, results, strict=True):
+            responses[key] = f"[error: {result}]" if isinstance(result, Exception) else result
+
+        rounds.append(RoundResult(turn=turn, responses=dict(responses)))
+        conclusion = extract_conclusion(responses)
+        if conclusion:
+            return ConsensusResult(
+                answer=conclusion,
+                reached_consensus=True,
+                stop_reason="consensus",
+                rounds=rounds,
+            )
+
+        next_user_message = (
+            "Here is what everyone said this round:\n\n"
+            f"{format_round_summary(responses)}"
+        )
+        for key in MODEL_KEYS:
+            histories[key].append({"role": "assistant", "content": responses[key]})
+            histories[key].append({"role": "user", "content": next_user_message})
+
+    return ConsensusResult(
+        answer=(
+            "No consensus was reached. Last-round responses:\n\n"
+            f"{format_round_summary(responses)}"
+        ),
+        reached_consensus=False,
+        stop_reason="max_turns",
+        rounds=rounds,
+    )
+
+
+def run_question(question: str, config: ConsensusConfig) -> ConsensusResult:
+    return asyncio.run(run_chat([ChatMessage(role="user", content=question)], config))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "html2text>=2025.4.15",
     "requests>=2.32.5",
     "supabase>=2.0.0",
+    "anthropic>=0.72.0",
+    "openai>=2.0.0",
+    "google-genai>=1.36.0",
 ]
 
 [dependency-groups]

--- a/serve.py
+++ b/serve.py
@@ -3,6 +3,8 @@
 TLDR Newsletter Scraper backend with a proxy.
 """
 
+import dataclasses
+import asyncio
 from flask import Flask, request, jsonify, send_from_directory
 import logging
 import requests
@@ -11,6 +13,7 @@ import os
 import util
 import tldr_app
 import storage_service
+import consensus
 from summarizer import DEFAULT_MODEL, DEFAULT_SUMMARY_EFFORT
 from source_routes import source_bp
 
@@ -35,6 +38,14 @@ logger = logging.getLogger("serve")
 @app.route("/")
 def index():
     """Serve the React app"""
+    static_dist = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static', 'dist')
+    return send_from_directory(static_dist, 'index.html')
+
+
+@app.route("/consensus")
+@app.route("/consensus/")
+def consensus_index():
+    """Serve hidden consensus client."""
     static_dist = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static', 'dist')
     return send_from_directory(static_dist, 'index.html')
 
@@ -73,6 +84,51 @@ def scrape_newsletters_in_date_range():
             error,
         )
         return jsonify({"success": False, "error": str(error)}), 500
+
+
+@app.route("/api/consensus/health", methods=["GET"])
+def consensus_health():
+    """Expose consensus config for quick diagnostics."""
+    config = consensus.load_config()
+    return jsonify(
+        {
+            "success": True,
+            "thinking_level": config.thinking_level.value,
+            "max_turns": config.max_turns,
+            "models": {
+                "anthropic": config.anthropic_model,
+                "openai": config.openai_model,
+                "gemini": config.gemini_model,
+            },
+        }
+    )
+
+
+@app.route("/api/consensus/chat", methods=["POST"])
+def consensus_chat():
+    """Run hidden consensus flow."""
+    try:
+        data = request.get_json()
+        messages = [
+            consensus.ChatMessage(role=message["role"], content=message["content"])
+            for message in data["messages"]
+        ]
+        config = consensus.load_config(
+            thinking=data.get("thinking", "low"),
+            max_turns=int(data.get("max_turns", consensus.DEFAULT_MAX_TURNS)),
+        )
+        result = consensus.run_question(messages[-1].content, config) if len(messages) == 1 else asyncio.run(consensus.run_chat(messages, config))
+        return jsonify(
+            {
+                "success": True,
+                "result": dataclasses.asdict(result),
+            }
+        )
+    except ValueError as error:
+        return jsonify({"success": False, "error": str(error)}), 400
+    except Exception as error:
+        logger.exception("Consensus run failed error=%s", error)
+        return jsonify({"success": False, "error": repr(error)}), 500
 
 
 @app.route("/api/summarize-url", methods=["POST"])

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -72,6 +72,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.91.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/b5/f39ae52ce035490217203581b9bfca8ca853c3a497961d0e5a2f091d0233/anthropic-0.91.0.tar.gz", hash = "sha256:a6afd894d55c26504e3d33909fb3f174d0db7d63369bfe9bb387da3e2806076a", size = 599272, upload-time = "2026-04-07T18:41:17.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/1e/7f06da237fde2d7f760a1b61a554c0e780dffe1d264e5aacd0287a7a142b/anthropic-0.91.0-py3-none-any.whl", hash = "sha256:b8672878642774198aa6272f40eb526b9ca11c2a72d4a935d867d445c7371f68", size = 481829, upload-time = "2026-04-07T18:41:15.326Z" },
 ]
 
 [[package]]
@@ -368,6 +387,24 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
 name = "feedparser"
 version = "6.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -517,6 +554,45 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64", size = 333825, upload-time = "2026-03-12T19:30:58.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7", size = 240737, upload-time = "2026-03-12T19:30:53.159Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/dd/28e4682904b183acbfad3fe6409f13a42f69bb8eab6e882d3bcbea1dde01/google_genai-1.70.0.tar.gz", hash = "sha256:36b67b0fc6f319e08d1f1efd808b790107b1809c8743a05d55dfcf9d9fad7719", size = 519550, upload-time = "2026-04-01T10:52:46.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/a3/d4564c8a9beaf6a3cef8d70fa6354318572cebfee65db4f01af0d41f45ba/google_genai-1.70.0-py3-none-any.whl", hash = "sha256:b74c24549d8b4208f4c736fd11857374788e1ffffc725de45d706e35c97fceee", size = 760584, upload-time = "2026-04-01T10:52:44.349Z" },
 ]
 
 [[package]]
@@ -701,6 +777,91 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/29/499f8c9eaa8a16751b1c0e45e6f5f1761d180da873d417996cc7bddc8eef/jiter-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ea026e70a9a28ebbdddcbcf0f1323128a8db66898a06eaad3a4e62d2f554d096", size = 311157, upload-time = "2026-02-02T12:35:37.758Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f6/566364c777d2ab450b92100bea11333c64c38d32caf8dc378b48e5b20c46/jiter-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66aa3e663840152d18cc8ff1e4faad3dd181373491b9cfdc6004b92198d67911", size = 319729, upload-time = "2026-02-02T12:35:39.246Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/560f13ec5e4f116d8ad2658781646cca91b617ae3b8758d4a5076b278f70/jiter-0.13.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3524798e70655ff19aec58c7d05adb1f074fecff62da857ea9be2b908b6d701", size = 354766, upload-time = "2026-02-02T12:35:40.662Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/0d/061faffcfe94608cbc28a0d42a77a74222bdf5055ccdbe5fd2292b94f510/jiter-0.13.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ec7e287d7fbd02cb6e22f9a00dd9c9cd504c40a61f2c61e7e1f9690a82726b4c", size = 362587, upload-time = "2026-02-02T12:35:42.025Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c9/c66a7864982fd38a9773ec6e932e0398d1262677b8c60faecd02ffb67bf3/jiter-0.13.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:47455245307e4debf2ce6c6e65a717550a0244231240dcf3b8f7d64e4c2f22f4", size = 487537, upload-time = "2026-02-02T12:35:43.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/86/84eb4352cd3668f16d1a88929b5888a3fe0418ea8c1dfc2ad4e7bf6e069a/jiter-0.13.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee9da221dca6e0429c2704c1b3655fe7b025204a71d4d9b73390c759d776d165", size = 373717, upload-time = "2026-02-02T12:35:44.928Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/09/9fe4c159358176f82d4390407a03f506a8659ed13ca3ac93a843402acecf/jiter-0.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24ab43126d5e05f3d53a36a8e11eb2f23304c6c1117844aaaf9a0aa5e40b5018", size = 362683, upload-time = "2026-02-02T12:35:46.636Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/5e/85f3ab9caca0c1d0897937d378b4a515cae9e119730563572361ea0c48ae/jiter-0.13.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9da38b4fedde4fb528c740c2564628fbab737166a0e73d6d46cb4bb5463ff411", size = 392345, upload-time = "2026-02-02T12:35:48.088Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4c/05b8629ad546191939e6f0c2f17e29f542a398f4a52fb987bc70b6d1eb8b/jiter-0.13.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0b34c519e17658ed88d5047999a93547f8889f3c1824120c26ad6be5f27b6cf5", size = 517775, upload-time = "2026-02-02T12:35:49.482Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/88/367ea2eb6bc582c7052e4baf5ddf57ebe5ab924a88e0e09830dfb585c02d/jiter-0.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d2a6394e6af690d462310a86b53c47ad75ac8c21dc79f120714ea449979cb1d3", size = 551325, upload-time = "2026-02-02T12:35:51.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/12/fa377ffb94a2f28c41afaed093e0d70cfe512035d5ecb0cad0ae4792d35e/jiter-0.13.0-cp311-cp311-win32.whl", hash = "sha256:0f0c065695f616a27c920a56ad0d4fc46415ef8b806bf8fc1cacf25002bd24e1", size = 204709, upload-time = "2026-02-02T12:35:52.467Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/16/8e8203ce92f844dfcd3d9d6a5a7322c77077248dbb12da52d23193a839cd/jiter-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:0733312953b909688ae3c2d58d043aa040f9f1a6a75693defed7bc2cc4bf2654", size = 204560, upload-time = "2026-02-02T12:35:53.925Z" },
+    { url = "https://files.pythonhosted.org/packages/44/26/97cc40663deb17b9e13c3a5cf29251788c271b18ee4d262c8f94798b8336/jiter-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:5d9b34ad56761b3bf0fbe8f7e55468704107608512350962d3317ffd7a4382d5", size = 189608, upload-time = "2026-02-02T12:35:55.304Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/30/7687e4f87086829955013ca12a9233523349767f69653ebc27036313def9/jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663", size = 307958, upload-time = "2026-02-02T12:35:57.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/27/e57f9a783246ed95481e6749cc5002a8a767a73177a83c63ea71f0528b90/jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505", size = 318597, upload-time = "2026-02-02T12:35:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/52/e5719a60ac5d4d7c5995461a94ad5ef962a37c8bf5b088390e6fad59b2ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152", size = 348821, upload-time = "2026-02-02T12:36:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/61/db/c1efc32b8ba4c740ab3fc2d037d8753f67685f475e26b9d6536a4322bcdd/jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726", size = 364163, upload-time = "2026-02-02T12:36:01.937Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8a/fb75556236047c8806995671a18e4a0ad646ed255276f51a20f32dceaeec/jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0", size = 483709, upload-time = "2026-02-02T12:36:03.41Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/16/43512e6ee863875693a8e6f6d532e19d650779d6ba9a81593ae40a9088ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089", size = 370480, upload-time = "2026-02-02T12:36:04.791Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4c/09b93e30e984a187bc8aaa3510e1ec8dcbdcd71ca05d2f56aac0492453aa/jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93", size = 360735, upload-time = "2026-02-02T12:36:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1b/46c5e349019874ec5dfa508c14c37e29864ea108d376ae26d90bee238cd7/jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08", size = 391814, upload-time = "2026-02-02T12:36:08.368Z" },
+    { url = "https://files.pythonhosted.org/packages/15/9e/26184760e85baee7162ad37b7912797d2077718476bf91517641c92b3639/jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2", size = 513990, upload-time = "2026-02-02T12:36:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/34/2c9355247d6debad57a0a15e76ab1566ab799388042743656e566b3b7de1/jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228", size = 548021, upload-time = "2026-02-02T12:36:11.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4a/9f2c23255d04a834398b9c2e0e665382116911dc4d06b795710503cdad25/jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394", size = 203024, upload-time = "2026-02-02T12:36:12.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ee/f0ae675a957ae5a8f160be3e87acea6b11dc7b89f6b7ab057e77b2d2b13a/jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92", size = 205424, upload-time = "2026-02-02T12:36:13.93Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ae611edf913d3cbf02c97cdb90374af2082c48d7190d74c1111dde08bcdd/jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9", size = 186818, upload-time = "2026-02-02T12:36:15.308Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/7ee5a6ff4b9991e1a45263bfc46731634c4a2bde27dfda6c8251df2d958c/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf", size = 306897, upload-time = "2026-02-02T12:36:16.748Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/02/be5b870d1d2be5dd6a91bdfb90f248fbb7dcbd21338f092c6b89817c3dbf/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a", size = 317507, upload-time = "2026-02-02T12:36:18.351Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/b25d2ec333615f5f284f3a4024f7ce68cfa0604c322c6808b2344c7f5d2b/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb", size = 350560, upload-time = "2026-02-02T12:36:19.746Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ec/74dcb99fef0aca9fbe56b303bf79f6bd839010cb18ad41000bf6cc71eec0/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2", size = 363232, upload-time = "2026-02-02T12:36:21.243Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/37/f17375e0bb2f6a812d4dd92d7616e41917f740f3e71343627da9db2824ce/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f", size = 483727, upload-time = "2026-02-02T12:36:22.688Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d2/a71160a5ae1a1e66c1395b37ef77da67513b0adba73b993a27fbe47eb048/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159", size = 370799, upload-time = "2026-02-02T12:36:24.106Z" },
+    { url = "https://files.pythonhosted.org/packages/01/99/ed5e478ff0eb4e8aa5fd998f9d69603c9fd3f32de3bd16c2b1194f68361c/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663", size = 359120, upload-time = "2026-02-02T12:36:25.519Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/7ffd08203277a813f732ba897352797fa9493faf8dc7995b31f3d9cb9488/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa", size = 390664, upload-time = "2026-02-02T12:36:26.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/e0787856196d6d346264d6dcccb01f741e5f0bd014c1d9a2ebe149caf4f3/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820", size = 513543, upload-time = "2026-02-02T12:36:28.217Z" },
+    { url = "https://files.pythonhosted.org/packages/65/50/ecbd258181c4313cf79bca6c88fb63207d04d5bf5e4f65174114d072aa55/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68", size = 547262, upload-time = "2026-02-02T12:36:29.678Z" },
+    { url = "https://files.pythonhosted.org/packages/27/da/68f38d12e7111d2016cd198161b36e1f042bd115c169255bcb7ec823a3bf/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72", size = 200630, upload-time = "2026-02-02T12:36:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/25/65/3bd1a972c9a08ecd22eb3b08a95d1941ebe6938aea620c246cf426ae09c2/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc", size = 202602, upload-time = "2026-02-02T12:36:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/15/fe/13bd3678a311aa67686bb303654792c48206a112068f8b0b21426eb6851e/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b", size = 185939, upload-time = "2026-02-02T12:36:35.065Z" },
+    { url = "https://files.pythonhosted.org/packages/49/19/a929ec002ad3228bc97ca01dbb14f7632fffdc84a95ec92ceaf4145688ae/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10", size = 316616, upload-time = "2026-02-02T12:36:36.579Z" },
+    { url = "https://files.pythonhosted.org/packages/52/56/d19a9a194afa37c1728831e5fb81b7722c3de18a3109e8f282bfc23e587a/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef", size = 346850, upload-time = "2026-02-02T12:36:38.058Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/94e831c6bf287754a8a019cb966ed39ff8be6ab78cadecf08df3bb02d505/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6", size = 358551, upload-time = "2026-02-02T12:36:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ec/a4c72c822695fa80e55d2b4142b73f0012035d9fcf90eccc56bc060db37c/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d", size = 201950, upload-time = "2026-02-02T12:36:40.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/00/393553ec27b824fbc29047e9c7cd4a3951d7fbe4a76743f17e44034fa4e4/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d", size = 185852, upload-time = "2026-02-02T12:36:42.077Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
+    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
+    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
+    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b3/3c29819a27178d0e461a8571fb63c6ae38be6dc36b78b3ec2876bbd6a910/jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b1cbfa133241d0e6bdab48dcdc2604e8ba81512f6bbd68ec3e8e1357dd3c316c", size = 307016, upload-time = "2026-02-02T12:37:42.755Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/60993e4b07b1ac5ebe46da7aa99fdbb802eb986c38d26e3883ac0125c4e0/jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:db367d8be9fad6e8ebbac4a7578b7af562e506211036cba2c06c3b998603c3d2", size = 305024, upload-time = "2026-02-02T12:37:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fa/2227e590e9cf98803db2811f172b2d6460a21539ab73006f251c66f44b14/jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45f6f8efb2f3b0603092401dc2df79fa89ccbc027aaba4174d2d4133ed661434", size = 339337, upload-time = "2026-02-02T12:37:46.668Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/92/015173281f7eb96c0ef580c997da8ef50870d4f7f4c9e03c845a1d62ae04/jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:597245258e6ad085d064780abfb23a284d418d3e61c57362d9449c6c7317ee2d", size = 346395, upload-time = "2026-02-02T12:37:48.09Z" },
+    { url = "https://files.pythonhosted.org/packages/80/60/e50fa45dd7e2eae049f0ce964663849e897300433921198aef94b6ffa23a/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a", size = 305169, upload-time = "2026-02-02T12:37:50.376Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -875,6 +1036,25 @@ wheels = [
 ]
 
 [[package]]
+name = "openai"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1023,6 +1203,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1329,17 +1530,29 @@ wheels = [
 ]
 
 [[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
 name = "tldr-scraper"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "beautifulsoup4" },
     { name = "curl-cffi" },
     { name = "feedparser" },
     { name = "firecrawl-py" },
     { name = "flask" },
+    { name = "google-genai" },
     { name = "haxor" },
     { name = "html2text" },
+    { name = "openai" },
     { name = "requests" },
     { name = "supabase" },
 ]
@@ -1352,13 +1565,16 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.72.0" },
     { name = "beautifulsoup4", specifier = ">=4.13.5" },
     { name = "curl-cffi", specifier = ">=0.13.0" },
     { name = "feedparser", specifier = ">=6.0.0" },
     { name = "firecrawl-py", specifier = ">=1.11.0" },
     { name = "flask", specifier = ">=3.1.2" },
+    { name = "google-genai", specifier = ">=1.36.0" },
     { name = "haxor", specifier = ">=1.2.4" },
     { name = "html2text", specifier = ">=2025.4.15" },
+    { name = "openai", specifier = ">=2.0.0" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "supabase", specifier = ">=2.0.0" },
 ]
@@ -1367,6 +1583,18 @@ requires-dist = [
 dev = [
     { name = "playwright", specifier = ">=1.57.0" },
     { name = "pytest", specifier = ">=9.0.2" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation

- Provide a reusable orchestration layer to run a round-based consensus loop between Claude, GPT and Gemini and expose the converged answer to callers.
- Offer both a CLI skill and a hidden web client so internal users can run multi-model debates without a public web server.

### Description

- Add `consensus.py` implementing the consensus orchestration, async model adapters for Anthropic/OpenAI/Gemini, convergence detection via `<conclusion>...</conclusion>`, and utility functions to run rounds and format results.
- Add a CLI script at `.agents/skills/consensus/scripts/run_consensus.py` and skill doc at `.agents/skills/consensus/SKILL.md` to run the flow outside the web UI.
- Add a hidden React client (`client/src/consensus/ConsensusApp.jsx` and `consensus.css`) and mount it at the `/consensus` route by updating `client/src/main.jsx` and `serve.py` to serve the client and provide API endpoints (`/api/consensus/health`, `/api/consensus/chat`).
- Update Python packaging (`pyproject.toml`) and lock files (`uv.lock`) and add runtime deps for `anthropic`, `openai`, and `google-genai` to support the new model integrations; minor client `package-lock.json` tweaks included.

### Testing

- Ran the existing Python test suite with `pytest` and the test run completed successfully.
- No new automated unit tests were added for the consensus logic in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5f15498d883329755bf5e87efd523)