### PR TITLE
refactor: Consolidate git hooks — minimal set with shared util.sh

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-03-29 14:51, 8fb736a
+last_updated: 2026-04-08 14:02
 ---
 # Git Hooks
 
@@ -36,20 +36,17 @@ Performs two tasks:
 - Runs biome lint if `client/` files are staged (no file modifications)
 - Exits non-zero to block commit if linting fails
 
-### pre-merge-commit
-
-Automatically generates `PROJECT_STRUCTURE.md` using a Python script before merge commits so the working tree stays in sync.
-
-**Requirements:**
-- Python 3.11+ (uses `scripts/generate_tree.py`)
-
-The Python script is a drop-in replacement for `eza` to avoid installation time.
-
 ### post-checkout
 
 Ensures the local clone has the `merge.ours` driver configured so Git respects the `PROJECT_STRUCTURE.md merge=ours` rule from `.gitattributes`.
 
-Also regenerates `PROJECT_STRUCTURE.md` using the Python script to ensure the file is present and up-to-date when switching branches.
+Regenerates `PROJECT_STRUCTURE.md` to ensure it is present and up-to-date when switching branches or after a fresh clone.
+
+### post-merge
+
+Regenerates `PROJECT_STRUCTURE.md` and syncs external subdirectories into the working tree after every merge/pull.
+
+Synced directories are registered in `.git/info/exclude` so they remain untracked without polluting `.gitignore`.
 
 ## GitHub Actions
 

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -2,5 +2,5 @@
 set -eo pipefail
 
 source ./.githooks/util.sh
-generate_project_structure
+generate_project_structure || true
 sync_external_dirs

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-source ./.githooks/sync-subdir.sh
-
-echo "[post-merge] Syncing external subdirectories..."
-sync_untracked "https://github.com/giladbarnea/llm-templates" "skills/prompt-subagent" ".agents/skills/prompt-subagent"
-echo "[post-merge] Sync complete."
+source ./.githooks/util.sh
+generate_project_structure
+sync_external_dirs

--- a/.githooks/pre-merge-commit
+++ b/.githooks/pre-merge-commit
@@ -1,9 +1,0 @@
-#!/bin/bash
-#
-# Pre-merge-commit hook that generates PROJECT_STRUCTURE.md
-# This runs before creating a merge commit
-
-source ./.githooks/util.sh
-generate_project_structure
-
-exit 0

--- a/.githooks/sync-subdir.sh
+++ b/.githooks/sync-subdir.sh
@@ -11,4 +11,9 @@ sync_untracked() {
     git fetch "$repo_url" main --quiet
     mkdir -p "$dest_dir"
     git archive FETCH_HEAD:"$src_dir" | tar -x -C "$dest_dir"
+
+    local exclude_file
+    exclude_file="$(git rev-parse --git-dir)/info/exclude"
+    mkdir -p "$(dirname "$exclude_file")"
+    grep -qxF "$dest_dir" "$exclude_file" 2>/dev/null || echo "$dest_dir" >> "$exclude_file"
 }

--- a/.githooks/util.sh
+++ b/.githooks/util.sh
@@ -1,15 +1,48 @@
 #!/bin/bash
 
+_HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_HOOKS_DIR/sync-subdir.sh"
+
+function ensure_agent_symlinks() {
+	local dot_dirs=(".claude" ".codex" ".gemini" ".pi")
+	local workdir="${1:-${SERVER_CONTEXT_WORKDIR:-$PWD}}"
+
+	for dir in "${dot_dirs[@]}"; do
+		mkdir -p "$workdir/$dir"
+		for target in "agents" "skills"; do
+			local link_path="$workdir/$dir/$target"
+			if [[ -L "$link_path" ]]; then
+				local current_target
+				current_target=$(readlink "$link_path")
+				if [[ "$current_target" != "../.agents/$target" ]]; then
+					rm "$link_path"
+					ln -s "../.agents/$target" "$link_path"
+				fi
+			else
+				rm -rf "$link_path"
+				ln -s "../.agents/$target" "$link_path"
+			fi
+		done
+	done
+}
+
 function generate_project_structure() {
-	SETUP_QUIET=true SETUP_SH_SKIP_MAIN=1 source ./setup.sh
-	ensure_agent_symlinks "$SERVER_CONTEXT_WORKDIR"
-	_ignore_glob='.git|node_modules|__pycache__|*.pyc|.venv|static|*.vscode|*.cursor|experimental|thoughts/done|docs|.run'
+	local workdir="${SERVER_CONTEXT_WORKDIR:-$PWD}"
+	export PATH="${HOME}/.local/bin:${PATH}"
+	ensure_agent_symlinks "$workdir"
+	local ignore_glob='.git|node_modules|__pycache__|*.pyc|.venv|static|*.vscode|*.cursor|experimental|thoughts/done|docs|.run'
 	uv run python3 scripts/generate_tree.py \
 		--classify \
 		--icons \
 		--tree \
 		--git-ignore \
 		--all \
-		--ignore-glob "$_ignore_glob" \
+		--ignore-glob "$ignore_glob" \
 		. > PROJECT_STRUCTURE.md
+}
+
+function sync_external_dirs() {
+	echo "[sync_external_dirs] Syncing external subdirectories..."
+	sync_untracked "https://github.com/giladbarnea/llm-templates" "skills/prompt-subagent" ".agents/skills/prompt-subagent"
+	echo "[sync_external_dirs] Sync complete."
 }

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,7 @@ fi
 
 # Source common utilities
 source "$SERVER_CONTEXT_WORKDIR/scripts/setup/common.sh"
+source "$SERVER_CONTEXT_WORKDIR/.githooks/util.sh"
 
 # Override message/error for setup.sh context (since this file is sourced, not executed)
 function error() {
@@ -369,32 +370,6 @@ function build_client() {
   fi
 }
 
-#region ----[ Configure Agent Symlinks ]----
-function ensure_agent_symlinks() {
-  local dot_dirs=(".claude" ".codex" ".gemini" ".pi")
-  local workdir="${1:-$SERVER_CONTEXT_WORKDIR}"
-  [[ -z "$workdir" ]] && workdir="$PWD"
-
-  for dir in "${dot_dirs[@]}"; do
-    mkdir -p "$workdir/$dir"
-    for target in "agents" "skills"; do
-      local link_path="$workdir/$dir/$target"
-      if [[ -L "$link_path" ]]; then
-        # Already a symlink, verify it points to the right place
-        local current_target=$(readlink "$link_path")
-        if [[ "$current_target" != "../.agents/$target" ]]; then
-          rm "$link_path"
-          ln -s "../.agents/$target" "$link_path"
-        fi
-      else
-        # Not a symlink, remove and create one
-        rm -rf "$link_path"
-        ln -s "../.agents/$target" "$link_path"
-      fi
-    done
-  done
-}
-
 # main [-q,-quiet]
 # Idempotent environment and dependencies setup, installation, and verification.
 function main() {
@@ -448,20 +423,9 @@ function main() {
 
   #region ----[ Prepare & Print Docs ]----
 
-  [[ "$quiet" == false ]] && message "[$0] Configuring git hooks..."
-  if [[ -d "$workdir/.githooks" ]]; then
-    if git config core.hooksPath .githooks; then
-      [[ "$quiet" == false ]] && message "[$0] Git hooks configured to use .githooks directory"
-
-      if [[ -x "$workdir/.githooks/pre-merge-commit" ]]; then
-        [[ "$quiet" == false ]] && message "[$0] Running pre-merge-commit hook to generate PROJECT_STRUCTURE.md..."
-        (builtin cd "$workdir" && ./.githooks/pre-merge-commit)
-        [[ "$quiet" == false && -f PROJECT_STRUCTURE.md ]] && message "[$0] Generated PROJECT_STRUCTURE.md via git hook"
-      fi
-    fi
-  fi
-
-  ensure_agent_symlinks "$workdir"
+  git config core.hooksPath .githooks 2>/dev/null || true
+  generate_project_structure || true
+  sync_external_dirs || true
 
   #region ----[ Env Vars Validation ]----
 


### PR DESCRIPTION
- Delete pre-merge-commit: redundant since PROJECT_STRUCTURE.md is
  ephemeral/untracked; post-checkout and post-merge cover every
  meaningful moment (clone, branch switch, pull/merge)
- util.sh: break circular util.sh→setup.sh dependency by moving
  ensure_agent_symlinks here; add sync_external_dirs() absorbing the
  inline logic from post-merge; source sync-subdir.sh via BASH_SOURCE
- post-merge: replace inline sync with util.sh functions; now also
  regenerates PROJECT_STRUCTURE.md after merges
- setup.sh: source util.sh directly; call generate_project_structure
  and sync_external_dirs inline instead of shelling out to the deleted
  hook; remove ensure_agent_symlinks definition

https://claude.ai/code/session_019LvbiqW6YqP5LaRKbwG7Wc