### PR TITLE
docs: refresh context-menu research paths after client dedup refactor

### DIFF
--- a/thoughts/26-04-07-context-menu-research/plans/plan-final.md
+++ b/thoughts/26-04-07-context-menu-research/plans/plan-final.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-04-08 19:29, e1aaa72
+last_updated: 2026-04-09 15:09
 ---
 # Finalized Plan: Overlay Context Menu (Zen + Digest)
 
@@ -19,13 +19,13 @@ This yields a smaller, clearer implementation surface than either doc alone.
 ## Scope
 
 Implement a shared right-click context menu for overlay reading surfaces only:
-- `ZenModeOverlay` in `client/src/components/ArticleCard.jsx`
+- `ZenModeOverlay` in `client/src/components/ZenModeOverlay.jsx`
 - `DigestOverlay` in `client/src/components/DigestOverlay.jsx`
 
 ### Out of Scope
 - No card/feed-level context menu.
 - No touch long-press custom menu.
-- No changes to lock ownership (`zenLockOwner` behavior stays intact).
+- No changes to lock ownership (`client/src/lib/zenLock.js` behavior stays intact).
 - No changes to pull-to-close / overscroll gesture hooks.
 
 ## Implementation Plan
@@ -60,11 +60,11 @@ Implement a presentational component:
 ## Phase 2 — Overlay Integration
 
 ### 1) Zen integration
-**File**: `client/src/components/ArticleCard.jsx`
+**File**: `client/src/components/ZenModeOverlay.jsx`
 
 Inside `ZenModeOverlay`:
 - use `useOverlayContextMenu`
-- bind `onContextMenu` to overlay scroll/content surface (`scrollRef` area)
+- thread `onContextMenu` through to the shared `BaseOverlay` scroll/content surface (`scrollRef` area)
 - render `OverlayContextMenu`
 - ensure menu state closes on overlay close/unmount
 
@@ -72,7 +72,7 @@ Inside `ZenModeOverlay`:
 **File**: `client/src/components/DigestOverlay.jsx`
 
 Mirror the same pattern as Zen:
-- same attach point semantics
+- same attach point semantics through `BaseOverlay`
 - same Escape arbitration behavior
 - same close/unmount cleanup
 

--- a/thoughts/26-04-07-context-menu-research/plans/plan-g.md
+++ b/thoughts/26-04-07-context-menu-research/plans/plan-g.md
@@ -1,35 +1,35 @@
 ---
-last_updated: 2026-04-08 19:29, e1aaa72
+last_updated: 2026-04-09 15:09
 ---
 # Context Menu Implementation Plan
 
 ## Overview
-Implement a shared custom context menu (right-click) for both `ZenModeOverlay` and `DigestOverlay`. Currently, no custom context menu exists, and browser default behavior is used. The goal is to provide a consistent custom context menu for these overlays without interfering with the existing touch gestures (pull-to-close, overscroll-up) or the `zenLockOwner` exclusivity mechanism.
+Implement a shared custom context menu (right-click) for both `ZenModeOverlay` and `DigestOverlay`. Currently, no custom context menu exists, and browser default behavior is used. The goal is to provide a consistent custom context menu for these overlays without interfering with the existing touch gestures (pull-to-close, overscroll-up) or the shared `zenLockOwner` exclusivity mechanism in `client/src/lib/zenLock.js`.
 
 ## Current State Analysis
-- Both `ZenModeOverlay` (in `ArticleCard.jsx`) and `DigestOverlay` (in `DigestOverlay.jsx`) render as `fixed inset-0 z-[100]` portals attached to `document.body`.
-- They share a common structure: a fixed header and a flex-1 scrolling content area (`<div ref={scrollRef}>`).
+- `ZenModeOverlay` (in `ZenModeOverlay.jsx`) and `DigestOverlay` (in `DigestOverlay.jsx`) now render through `BaseOverlay.jsx`, which is the `fixed inset-0 z-[100]` portal attached to `document.body`.
+- They still share a common structure: a fixed header and a flex-1 scrolling content area (`<div ref={scrollRef}>`) owned by `BaseOverlay`.
 - Touch gestures (pull-to-close, overscroll-up) are bound to the `containerRef` and `scrollRef` respectively.
 - `useLongPress` explicitly ignores non-primary mouse buttons (`e.button !== 0`), meaning right-clicks are ignored by cards.
 - There is no existing `onContextMenu` handler in `client/src/`.
-- `useSummary` and `useDigest` share a singleton lock (`zenLockOwner`) to ensure only one overlay is open at a time.
+- `useSummary` and `useDigest` share a singleton lock from `client/src/lib/zenLock.js` to ensure only one overlay is open at a time.
 
 ### Key Discoveries:
-- **Event Scoping:** The `onContextMenu` handler should be attached to the scrolling content container (`<div ref={scrollRef}>`), not the entire document or overlay container, to explicitly target the reading area.
+- **Event Scoping:** The `onContextMenu` handler should be attached to the scrolling content container (`<div ref={scrollRef}>`) in `BaseOverlay`, not the entire document or overlay container, to explicitly target the reading area.
 - **Z-Index:** The context menu needs a z-index higher than the overlays (`z-[100]`), e.g., `z-[150]`.
 - **Exclusivity:** The context menu must be localized (ephemeral state within the overlay component itself) so it naturally unmounts when the overlay closes.
 - **Escape Key Handling:** Both overlays currently listen for `Escape` to close themselves. If the context menu is open, pressing `Escape` should close the menu but *not* the overlay. This requires `e.stopPropagation()` when the menu handles the keydown, or conditional logic in the overlay's escape handler.
 
 ## What We're NOT Doing
 - We are NOT implementing custom context menus for the main feed/article cards (sticking strictly to the overlays as per research).
-- We are NOT modifying the `zenLockOwner` mechanism. The context menu will be internal state to the overlays.
+- We are NOT modifying the `zenLockOwner` mechanism in `client/src/lib/zenLock.js`. The context menu will be internal state to the overlays.
 - We are NOT adding long-press fallback for touch devices (unless it organically fits a cross-platform pointer approach, but the focus is right-click context menu).
 - We are NOT blocking standard text selection in the prose area.
 
 ## Implementation Approach
 1. Create a `useOverlayContextMenu` hook to manage the state (isOpen, x, y coordinates) and behavior (open, close, positioning, click-outside, escape to close) of the context menu.
 2. Create an `OverlayContextMenu` component to render the menu visually at the captured coordinates.
-3. Integrate the hook and component into both `ZenModeOverlay` and `DigestOverlay`.
+3. Integrate the hook and component into both `ZenModeOverlay` and `DigestOverlay`, threading the attach point through `BaseOverlay`.
 
 ## Phase 1: Shared Hook and Component
 
@@ -89,12 +89,12 @@ Wire the shared hook and component into the existing `ZenModeOverlay` and `Diges
 ### Changes Required:
 
 #### 1. Integrate into ZenModeOverlay
-**File**: `client/src/components/ArticleCard.jsx`
+**File**: `client/src/components/ZenModeOverlay.jsx`
 **Changes**:
 - Import `useOverlayContextMenu` and `OverlayContextMenu`.
 - Initialize `const { isOpen, position, handleContextMenu, closeMenu } = useOverlayContextMenu();` inside `ZenModeOverlay`.
-- Attach `onContextMenu={handleContextMenu}` to the `<div ref={scrollRef} ...>` element.
-- Render `<OverlayContextMenu>` as a sibling to the content inside the overlay container.
+- Pass `onContextMenu={handleContextMenu}` through to the shared `<div ref={scrollRef} ...>` surface in `BaseOverlay`.
+- Render `<OverlayContextMenu>` from `ZenModeOverlay` as a sibling to the overlay shell.
 - For the menu items, add relevant actions (e.g., "Copy Text", "Close Overlay"). *Note: Exact actions aren't specified in research, so basic placeholder or standard actions will be implemented, specifically a "Close" action to mirror the header.*
 - Ensure the overlay's native escape listener does not fire if the context menu's escape listener caught the event (handled by the hook's stopPropagation, or by checking `if (isOpen) return;` in the overlay's escape handler).
 
@@ -103,7 +103,7 @@ Wire the shared hook and component into the existing `ZenModeOverlay` and `Diges
 **Changes**:
 - Apply the exact same integration pattern as `ZenModeOverlay`.
 - Import hook and component.
-- Attach `onContextMenu` to `<div ref={scrollRef} ...>`.
+- Pass `onContextMenu` through to the shared `BaseOverlay` scroll/content surface.
 - Render the menu component.
 
 ### Success Criteria:

--- a/thoughts/26-04-07-context-menu-research/plans/plan-x.md
+++ b/thoughts/26-04-07-context-menu-research/plans/plan-x.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-04-08 19:29, e1aaa72
+last_updated: 2026-04-09 15:09
 ---
 # Custom Context Menu in Zen/Digest Overlays Implementation Plan
 
@@ -9,9 +9,9 @@ Implement a shared custom context menu interaction that works consistently in bo
 
 ## Current State Analysis
 
-- `ZenModeOverlay` in `ArticleCard.jsx` and `DigestOverlay` in `DigestOverlay.jsx` use near-identical portal-based full-screen layouts with shared gesture hooks (`usePullToClose`, `useOverscrollUp`, `useScrollProgress`).
+- `ZenModeOverlay` in `ZenModeOverlay.jsx` and `DigestOverlay` in `DigestOverlay.jsx` are now thin wrappers around `BaseOverlay.jsx`, which owns the shared portal-based full-screen layout and gesture hooks (`usePullToClose`, `useOverscrollUp`, `useScrollProgress`).
 - Neither overlay handles `onContextMenu`; browser default context menu currently appears on right click.
-- Overlay exclusivity is controlled by `acquireZenLock`/`releaseZenLock` shared between `useSummary` and `useDigest`; this flow must remain unchanged.
+- Overlay exclusivity is controlled by `acquireZenLock`/`releaseZenLock` in `client/src/lib/zenLock.js`, shared between `useSummary` and `useDigest`; this flow must remain unchanged.
 - Existing long-press behavior (`useLongPress`) explicitly ignores non-primary mouse buttons, so right-click is currently not captured by that path.
 
 ## Desired End State
@@ -27,7 +27,7 @@ Right-clicking within summary/digest prose opens a project-owned context menu wi
 
 - No changes to digest/single-summary generation APIs.
 - No redesign of selection dock or card-level long-press behavior.
-- No changes to overlay lock acquisition/release (`zenLockOwner`) semantics.
+- No changes to overlay lock acquisition/release (`client/src/lib/zenLock.js`) semantics.
 - No global document-wide context menu override outside the two overlays.
 
 ## Implementation Approach
@@ -94,10 +94,10 @@ Wire the shared primitive into both overlay components in a way that preserves e
 ### Changes Required:
 
 #### 1. Wire into `ZenModeOverlay`
-**File**: `client/src/components/ArticleCard.jsx`
+**File**: `client/src/components/ZenModeOverlay.jsx`
 **Changes**:
 - Instantiate shared context-menu hook inside `ZenModeOverlay`.
-- Attach `onContextMenu` to prose container or a dedicated overlay content wrapper (not top-level container).
+- Thread `onContextMenu` through `ZenModeOverlay` into the shared `BaseOverlay` scroll/content wrapper (not the top-level container).
 - Define action set aligned with overlay affordances (e.g., open original link, mark consumed, close menu).
 - Reset menu state on overlay close/unmount.
 
@@ -111,6 +111,7 @@ Wire the shared primitive into both overlay components in a way that preserves e
 **File**: `client/src/components/DigestOverlay.jsx`
 **Changes**:
 - Mirror the same integration pattern used in `ZenModeOverlay`.
+- Thread the same handler through to the shared `BaseOverlay` scroll/content wrapper.
 - Use digest-specific action callbacks where needed (e.g., close digest via existing `onClose`, mark consumed via `onMarkRemoved`).
 - Keep behavior parity with summary overlay.
 
@@ -118,6 +119,7 @@ Wire the shared primitive into both overlay components in a way that preserves e
 **Files**:
 - `client/src/hooks/useSummary.js`
 - `client/src/hooks/useDigest.js`
+- `client/src/lib/zenLock.js`
 - `client/src/hooks/usePullToClose.js`
 - `client/src/hooks/useOverscrollUp.js`
 
@@ -148,7 +150,7 @@ Wire the shared primitive into both overlay components in a way that preserves e
 
 ### Integration Tests:
 - Overlay-level integration tests validating menu attach points in both `ZenModeOverlay` and `DigestOverlay`.
-- Lock lifecycle smoke tests ensuring `acquireZenLock`/`releaseZenLock` behavior is unaffected by menu open/close.
+- Lock lifecycle smoke tests ensuring `client/src/lib/zenLock.js` behavior is unaffected by menu open/close.
 
 ### Manual Testing Steps:
 1. Open a summary overlay, right-click prose, run each menu action.
@@ -162,10 +164,12 @@ Wire the shared primitive into both overlay components in a way that preserves e
 - Requirements and scope input: `thoughts/26-04-07-context-menu-research/research/description.md`
 - Supporting research map: `thoughts/26-04-07-context-menu-research/relevant-files.md`
 - Primary integration targets:
-  - `client/src/components/ArticleCard.jsx`
+  - `client/src/components/ZenModeOverlay.jsx`
   - `client/src/components/DigestOverlay.jsx`
+  - `client/src/components/BaseOverlay.jsx`
   - `client/src/hooks/useSummary.js`
   - `client/src/hooks/useDigest.js`
+  - `client/src/lib/zenLock.js`
   - `client/src/hooks/usePullToClose.js`
   - `client/src/hooks/useOverscrollUp.js`
   - `client/src/hooks/useLongPress.js`

--- a/thoughts/26-04-07-context-menu-research/relevant-files.md
+++ b/thoughts/26-04-07-context-menu-research/relevant-files.md
@@ -2,24 +2,33 @@
 date: 2026-04-07
 topic: "Custom Context Menu in Zen/Digest Overlays"
 status: complete
-last_updated: 2026-04-08 08:29, f1aa954
+last_updated: 2026-04-09 15:09
 ---
 # Context Menu in Zen/Digest Overlays — Relevant Files
  
 ## `client/src/components/ArticleCard.jsx`
-Contains `ZenModeOverlay` (inline component, lines ~26–132). Renders via `createPortal` to `document.body` at `z-[100]`. Has a fixed header (close button, domain link, mark-removed button, progress bar) and a scrollable content area with `.prose` + `dangerouslySetInnerHTML`. Uses `pull-to-close`, `overscroll-to-dismiss`, and `scroll-progress` hooks.
+Renders `ZenModeOverlay` when `summary.expanded && summary.html`. Still owns the card click/swipe/remove path that opens the single-article reading overlay.
+
+## `client/src/components/ZenModeOverlay.jsx`
+Standalone single-article overlay wrapper. Delegates the shared full-screen shell to `BaseOverlay`, passes the domain/meta header content, and renders summary HTML inside the shared prose surface.
+
+## `client/src/components/BaseOverlay.jsx`
+Owns `createPortal(..., document.body)` at `z-[100]`, the fixed header shell, the shared scrollable content area, `Escape` close handling, `document.body.style.overflow = 'hidden'`, and the shared `usePullToClose`, `useOverscrollUp`, and `useScrollProgress` hooks.
  
 ## `client/src/components/DigestOverlay.jsx`
-Standalone component, nearly identical structure to `ZenModeOverlay`. Rendered via `createPortal` in `App.jsx`. Controlled by `useDigest`. Header shows article count.
+Standalone digest overlay wrapper built on `BaseOverlay`. Rendered in `App.jsx`, controlled by `useDigest`, and its header shows the article count.
+
+## `client/src/lib/zenLock.js`
+Owns the zen-lock singleton (`zenLockOwner`, `acquireZenLock`, `releaseZenLock`) used to ensure only one overlay is open at a time.
  
 ## `client/src/hooks/useSummary.js`
-Owns the zen-lock singleton (`zenLockOwner`, `acquireZenLock`, `releaseZenLock`) — a module-level guard ensuring only one overlay is open at a time. Also owns summary fetch state and `expanded` open/close state.
+Owns summary fetch state and single-article `expanded` open/close state. Imports the shared lock helpers from `client/src/lib/zenLock.js`.
  
 ## `client/src/hooks/useDigest.js`
-Controls digest overlay open/close state, parallel to `useSummary`. Participates in the same zen-lock mechanism.
+Controls digest overlay open/close state, parallel to `useSummary`. Imports the same shared zen-lock helpers and participates in the same exclusivity mechanism.
  
 ## `client/src/hooks/useLongPress.js`
 Explicitly ignores non-primary mouse buttons (`e.button !== 0` guard on `pointerdown`). No right-click / context menu handling exists anywhere in the codebase.
  
 ## `client/src/App.jsx`
-Renders `DigestOverlay` via portal. Entry point for digest overlay lifecycle wiring.
+Renders `DigestOverlay` and wires `digest.expanded`, `digest.collapse(false)`, and `digest.collapse(true)` into it.

--- a/thoughts/26-04-07-context-menu-research/research/description.md
+++ b/thoughts/26-04-07-context-menu-research/research/description.md
@@ -2,42 +2,46 @@
 date: 2026-04-08
 topic: "Custom Context Menu in Zen/Digest Overlays"
 status: complete
-last_updated: 2026-04-08 10:22, 38b11fd
+last_updated: 2026-04-09 15:09
 ---
 # Research: Custom Context Menu in Zen/Digest Overlays
 
 ## Executive Summary
-Zen and Digest overlays are rendered as full-screen portals with nearly identical header/content structure and mobile-first touch gesture hooks. Neither overlay currently handles `onContextMenu`, and there is no global contextmenu interception in `client/src/`. Right-click interactions are therefore left to browser default behavior. For cards, `useLongPress` explicitly ignores non-primary mouse buttons, so right-click does not enter select mode. A custom context menu should be implemented as a shared overlay-level interaction primitive used by both `ZenModeOverlay` and `DigestOverlay`, while preserving existing pull-to-close and overscroll-to-complete touch gestures.
+Zen and Digest overlays are rendered as full-screen portals through a shared `BaseOverlay` shell with mobile-first touch gesture hooks. Neither overlay currently handles `onContextMenu`, and there is no global contextmenu interception in `client/src/`. Right-click interactions are therefore left to browser default behavior. For cards, `useLongPress` explicitly ignores non-primary mouse buttons, so right-click does not enter select mode. A custom context menu should be implemented as a shared overlay-level interaction primitive used by both `ZenModeOverlay` and `DigestOverlay`, while preserving existing pull-to-close and overscroll-to-complete touch gestures.
 
 ## Detailed Findings
 
 ### Overlay Rendering and Interaction Surface
 **Files**:
-- `client/src/components/ArticleCard.jsx`
+- `client/src/components/ZenModeOverlay.jsx`
 - `client/src/components/DigestOverlay.jsx`
+- `client/src/components/BaseOverlay.jsx`
 - `client/src/hooks/usePullToClose.js`
 - `client/src/hooks/useOverscrollUp.js`
 - `client/src/hooks/useScrollProgress.js`
 
 **Mechanism**:
-- `ZenModeOverlay` is defined inside `ArticleCard.jsx` and rendered with `createPortal(..., document.body)` as `fixed inset-0 z-[100]`. It contains:
-  - Header with close button, domain link, mark-consumed action.
-  - Scrollable content area using `dangerouslySetInnerHTML` for rendered summary HTML.
+- `ZenModeOverlay.jsx` is now a thin wrapper that supplies single-article header content plus rendered summary HTML to `BaseOverlay`.
+- `DigestOverlay.jsx` is the parallel digest wrapper that supplies the digest header and rendered digest HTML to `BaseOverlay`.
+- `BaseOverlay.jsx` renders the shared `createPortal(..., document.body)` shell as `fixed inset-0 z-[100]`. It contains:
+  - Header with close button, header slot, mark-consumed action, and progress bar.
+  - Shared scrollable content area that renders overlay children.
   - Pull-to-close hook bound to container/scroll refs.
   - Overscroll-up hook bound to scroll ref for bottom pull completion gesture.
-- `DigestOverlay` duplicates this layout and gesture pattern, also in a portal at `z-[100]` with similar close/mark-consumed controls and markdown HTML rendering.
-- Both overlays install `Escape` close handling and set `document.body.style.overflow = 'hidden'` while open.
+  - Shared `Escape` close handling and `document.body.style.overflow = 'hidden'` while open.
 
 ### Open/Close Ownership and Mutual Exclusion
 **Files**:
 - `client/src/hooks/useSummary.js`
 - `client/src/hooks/useDigest.js`
+- `client/src/lib/zenLock.js`
 - `client/src/App.jsx`
 
 **Mechanism**:
-- `useSummary` owns a module-level singleton lock (`zenLockOwner`) exposed via `acquireZenLock`/`releaseZenLock`.
+- `client/src/lib/zenLock.js` owns the module-level singleton lock (`zenLockOwner`) exposed via `acquireZenLock`/`releaseZenLock`.
 - Single-article summary overlay opens only when lock acquisition succeeds for owner `url`.
-- `useDigest` imports the same lock helpers and opens digest only when lock acquisition succeeds for owner `'digest'`.
+- `useSummary` and `useDigest` both import the shared lock helpers.
+- `useDigest` opens digest only when lock acquisition succeeds for owner `'digest'`.
 - Digest overlay lifecycle is wired in `App.jsx` by passing `digest.expanded`, `digest.collapse(false)` and `digest.collapse(true)` into `DigestOverlay`.
 - This lock means custom context menu UX must respect one-overlay-at-a-time assumptions; secondary modal layers inside an open overlay should not disturb lock ownership.
 
@@ -57,23 +61,25 @@ Zen and Digest overlays are rendered as full-screen portals with nearly identica
 ### Right-Click and Long-Press Behavior
 **Files**:
 - `client/src/hooks/useLongPress.js`
-- `client/src/components/ArticleCard.jsx`
+- `client/src/components/ZenModeOverlay.jsx`
+- `client/src/components/DigestOverlay.jsx`
+- `client/src/components/BaseOverlay.jsx`
 
 **Mechanism**:
 - `useLongPress` exits early for mouse non-primary buttons (`if (e.pointerType === 'mouse' && e.button !== 0) return`), so right-click is currently ignored by long-press logic.
 - There is no existing `onContextMenu` handler in `client/src`, so native browser context menu appears where supported.
-- Overlay content containers currently do not intercept right-click, and there is no shared custom context menu component/state machine.
+- The shared overlay content surface in `BaseOverlay` currently does not intercept right-click, and there is no shared custom context menu component/state machine.
 
 ## Architecture & Patterns
-- Portal-first overlays: both Zen and Digest render to `document.body` and own their own scroll/gesture surfaces.
-- Shared lock across independent hooks: `useDigest` reuses lock ownership from `useSummary` to enforce exclusivity.
+- Shared overlay shell: `BaseOverlay` owns the portal, scroll surface, and gesture hooks used by both Zen and Digest wrappers.
+- Shared lock across independent hooks: `useSummary` and `useDigest` both reuse lock ownership from `client/src/lib/zenLock.js` to enforce exclusivity.
 - Gesture-first mobile interactions: pull-to-close and overscroll-complete are touch event listeners on overlay container/scroll elements.
 - Localized open/close commands: each overlay controls its own close semantics and lifecycle side effects.
 
 ## Open Questions / Risks
 - [ ] **Event conflict risk**: Adding pointer/mouse handlers for custom context menu in overlay content may interfere with touch gesture hooks if listeners are attached too high in the DOM tree.
 - [ ] **Selection-in-prose risk**: Custom context menu should avoid blocking text selection and link opening inside rendered prose.
-- [ ] **Consistency risk**: Duplicated Zen/Digest overlay structures can drift; implementing context menu in one component only creates behavior mismatch.
+- [ ] **Consistency risk**: Zen/Digest wrapper behavior can drift around the shared `BaseOverlay`; implementing context menu in only one wrapper still creates behavior mismatch.
 - [ ] **Layering risk**: Context menu portal z-index must be above overlay (`z-[100]`) and toast layer (`z-[300]`) if interaction priority requires it.
 
 ## Concrete Integration Points
@@ -82,10 +88,10 @@ Zen and Digest overlays are rendered as full-screen portals with nearly identica
    - Handles `onContextMenu` (desktop) and optional long-press fallback inside overlay content area.
    - Closes on outside click, Escape, and overlay close.
 2. Attach the handler to both overlay content roots:
-   - `ZenModeOverlay` scroll/content wrapper.
-   - `DigestOverlay` scroll/content wrapper.
+   - Thread it through `ZenModeOverlay` into the shared `BaseOverlay` scroll/content wrapper.
+   - Thread it through `DigestOverlay` into the shared `BaseOverlay` scroll/content wrapper.
 3. Keep lifecycle ownership unchanged:
-   - Do **not** alter `zenLockOwner` semantics.
+   - Do **not** alter `client/src/lib/zenLock.js` semantics.
    - Menu visibility should be ephemeral UI state inside each overlay and reset on close.
 4. Ensure touch gestures remain authoritative:
    - Do not install blocking non-passive touch listeners beyond existing pull/overscroll hooks.


### PR DESCRIPTION
## Summary
Refresh the 26-04-07 context-menu research docs so their file paths and ownership descriptions match the post-dedup client layout from 81662be.

## What changed
- point Zen overlay references at `client/src/components/ZenModeOverlay.jsx`
- document shared overlay shell ownership in `client/src/components/BaseOverlay.jsx`
- point zen lock references at `client/src/lib/zenLock.js`
- keep digest wiring references aligned with current `App.jsx` ownership
- update plan wording so the context-menu attach point flows through `BaseOverlay`

## Verification
- reread all updated docs in full
- checked the refactor mapping with `gsd` against commit `81662be`
- no code changes; build not run