### PR TITLE
Fix mobile overflow in debate trace and add copy buttons

### DIFF
--- a/.githooks/util.sh
+++ b/.githooks/util.sh
@@ -31,6 +31,8 @@ function generate_project_structure() {
 	export PATH="${HOME}/.local/bin:${PATH}"
 	ensure_agent_symlinks "$workdir"
 	local ignore_glob='.git|node_modules|__pycache__|*.pyc|.venv|static|*.vscode|*.cursor|experimental|thoughts/done|docs|.run|.codex|.gemini|.claude/agents|.claude/skills|.pi/agents|.pi/skills|.agents/skills/react-best-practices/rules|.agents/skills/i-frontend-design/reference|.agents/skills/i-critique/reference'
+	local target="PROJECT_STRUCTURE.md"
+	local tmp; tmp=$(mktemp)
 	uv run python3 scripts/generate_tree.py \
 		--classify \
 		--icons \
@@ -38,7 +40,20 @@ function generate_project_structure() {
 		--git-ignore \
 		--all \
 		--ignore-glob "$ignore_glob" \
-		. > PROJECT_STRUCTURE.md
+		. > "$tmp"
+	uv run python3 - "$target" "$tmp" <<'PY'
+import sys, re
+from pathlib import Path
+target, tmp = Path(sys.argv[1]), Path(sys.argv[2])
+tree = tmp.read_text()
+frontmatter = ""
+if target.exists():
+    m = re.match(r'^---\s*\n.*?---\s*\n', target.read_text(), re.DOTALL)
+    if m:
+        frontmatter = m.group(0)
+target.write_text(frontmatter + tree if frontmatter else tree)
+PY
+	rm "$tmp"
 }
 
 function sync_external_dirs() {

--- a/client/src/consensus/ConsensusApp.jsx
+++ b/client/src/consensus/ConsensusApp.jsx
@@ -1,5 +1,5 @@
 import DOMPurify from 'dompurify'
-import { ChevronDown, ChevronUp, Radar, Send, Sparkles } from 'lucide-react'
+import { Check, ChevronDown, ChevronUp, Copy, Radar, Send, Sparkles } from 'lucide-react'
 import { marked } from 'marked'
 import { useMemo, useState } from 'react'
 import './consensus.css'
@@ -16,6 +16,22 @@ const STARTER_PROMPTS = [
   'Should I optimize for speed or maintainability in a one-person product? Give a nuanced recommendation.'
 ]
 
+function CopyButton({ text }) {
+  const [copied, setCopied] = useState(false)
+
+  function handleCopy() {
+    navigator.clipboard.writeText(text)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <button type="button" className="consensus-copy-btn" onClick={handleCopy} title="Copy to clipboard">
+      {copied ? <Check size={13} /> : <Copy size={13} />}
+    </button>
+  )
+}
+
 function MarkdownContent({ content, className }) {
   const html = DOMPurify.sanitize(marked.parse(content))
   return <div className={`consensus-md${className ? ` ${className}` : ''}`} dangerouslySetInnerHTML={{ __html: html }} />
@@ -24,7 +40,11 @@ function MarkdownContent({ content, className }) {
 function MessageBubble({ message }) {
   return (
     <div className={`consensus-message consensus-message-${message.role}`}>
-      <div className="consensus-message-meta">{message.role === 'user' ? 'You' : 'Consensus'}</div>
+      <div className="consensus-message-meta">
+        {message.role === 'user' ? 'You' : (
+          <>Consensus <CopyButton text={message.content} /></>
+        )}
+      </div>
       <div className="consensus-message-body">
         {message.role === 'assistant'
           ? <MarkdownContent content={message.content} />
@@ -65,7 +85,10 @@ function TracePanel({ rounds, reachedConsensus, stopReason, expanded, onToggle }
                 <summary>Round {round.turn}</summary>
                 {Object.entries(round.responses).map(([modelName, response]) => (
                   <div key={modelName} className="consensus-response" data-model={modelName}>
-                    <h4>{MODEL_LABELS[modelName] || modelName}</h4>
+                    <div className="consensus-response-header">
+                      <span>{MODEL_LABELS[modelName] || modelName}</span>
+                      <CopyButton text={response} />
+                    </div>
                     <div className="consensus-response-body">
                       <MarkdownContent content={response} className="consensus-trace-md" />
                     </div>

--- a/client/src/consensus/consensus.css
+++ b/client/src/consensus/consensus.css
@@ -252,7 +252,6 @@
   gap: 0.56rem;
   max-height: min(68dvh, 820px);
   overflow-y: auto;
-  overflow-x: hidden;
   min-width: 0;
   padding-right: 0.25rem;
 }
@@ -263,7 +262,6 @@
   padding: 0.6rem;
   background: #fbfdff;
   min-width: 0;
-  overflow: hidden;
 }
 
 .consensus-round summary {

--- a/client/src/consensus/consensus.css
+++ b/client/src/consensus/consensus.css
@@ -119,6 +119,9 @@
 }
 
 .consensus-message-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   font-size: 0.76rem;
   letter-spacing: 0.07em;
   text-transform: uppercase;
@@ -249,6 +252,8 @@
   gap: 0.56rem;
   max-height: min(68dvh, 820px);
   overflow-y: auto;
+  overflow-x: hidden;
+  min-width: 0;
   padding-right: 0.25rem;
 }
 
@@ -257,6 +262,8 @@
   border-radius: 0.8rem;
   padding: 0.6rem;
   background: #fbfdff;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .consensus-round summary {
@@ -277,8 +284,10 @@
   margin-top: 0.75rem;
 }
 
-.consensus-response h4 {
-  margin: 0;
+.consensus-response-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 0.42rem 0.75rem;
   font-size: 0.75rem;
   text-transform: uppercase;
@@ -288,27 +297,46 @@
   color: #355a89;
 }
 
-.consensus-response[data-model="claude"] h4 {
+.consensus-response[data-model="claude"] .consensus-response-header {
   background: #f3f0ff;
   border-color: #d4c5f9;
   color: #6d28d9;
 }
 
-.consensus-response[data-model="gpt"] h4 {
+.consensus-response[data-model="gpt"] .consensus-response-header {
   background: #ecfdf5;
   border-color: #a7f3d0;
   color: #065f46;
 }
 
-.consensus-response[data-model="gemini"] h4 {
+.consensus-response[data-model="gemini"] .consensus-response-header {
   background: #eff6ff;
   border-color: #bfdbfe;
   color: #1d4ed8;
 }
 
+.consensus-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  opacity: 0.55;
+  padding: 0.1rem;
+  border-radius: 0.25rem;
+  flex-shrink: 0;
+}
+
+.consensus-copy-btn:hover {
+  opacity: 1;
+}
+
 .consensus-response-body {
   max-height: 180px;
   overflow-y: auto;
+  overflow-x: hidden;
+  min-width: 0;
   padding: 0.65rem 0.75rem;
   overscroll-behavior: contain;
 }


### PR DESCRIPTION
- Add overflow-x: hidden + min-width: 0 to .consensus-rounds,
  .consensus-round, and .consensus-response-body to prevent long
  model responses from bleeding out of the trace panel on mobile
- Add CopyButton component (Copy/Check icon, 2s feedback)
- Add copy button to each model's response header bar in the trace
- Add copy button next to the "Consensus" label above assistant messages
- Replace h4 with .consensus-response-header (flex, space-between)
  to accommodate the copy button layout

https://claude.ai/code/session_01X7Z43RuLwsFRcKdvjNiknU