### PR TITLE
Add supabase-postgres-best-practices to external dir sync

### DIFF
--- a/.githooks/util.sh
+++ b/.githooks/util.sh
@@ -94,6 +94,7 @@ function _sync_tracked_submodules() {
 function _sync_external_dirs() {
 	echo "[sync_external_dirs] Syncing external subdirectories..."
 	sync_untracked "https://github.com/giladbarnea/llm-templates" "skills/prompt-subagent" ".agents/skills/prompt-subagent"
+	sync_untracked "https://github.com/giladbarnea/llm-templates" "skills/supabase-postgres-best-practices" ".agents/skills/supabase-postgres-best-practices"
 	echo "[sync_external_dirs] Sync complete."
 }
 


### PR DESCRIPTION
Syncs the supabase-postgres-best-practices skill from llm-templates repository during setup and post-merge hooks.

https://claude.ai/code/session_01QB2gx3NPwtFdzwcyHpktMi