### PR TITLE
Stop sanitizing transient 'loading' states when persisting daily payloads

### DIFF
--- a/client/src/hooks/useSummary.js
+++ b/client/src/hooks/useSummary.js
@@ -68,6 +68,7 @@ export function useSummary(date, url, type = 'summary') {
       {
         type: summaryDataReducer.SummaryDataEventType.SUMMARY_REQUESTED,
         effort: summaryEffort,
+        requestedAt: new Date().toISOString(),
       },
       `effort=${summaryEffort}`
     )

--- a/client/src/reducers/summaryDataReducer.js
+++ b/client/src/reducers/summaryDataReducer.js
@@ -5,6 +5,8 @@ export const SummaryDataStatus = Object.freeze({
   ERROR: 'error',
 })
 
+const MAX_LOADING_STATE_AGE_MILLISECONDS = 2 * 60 * 1000
+
 export const SummaryDataEventType = Object.freeze({
   SUMMARY_REQUESTED: 'SUMMARY_REQUESTED',
   SUMMARY_LOAD_SUCCEEDED: 'SUMMARY_LOAD_SUCCEEDED',
@@ -14,7 +16,27 @@ export const SummaryDataEventType = Object.freeze({
 })
 
 export function getSummaryDataStatus(summaryData) {
-  return summaryData?.status || SummaryDataStatus.UNKNOWN
+  const status = summaryData?.status || SummaryDataStatus.UNKNOWN
+  if (status !== SummaryDataStatus.LOADING) {
+    return status
+  }
+
+  const requestedAtIso = summaryData?.requestedAt
+  if (!requestedAtIso) {
+    return SummaryDataStatus.UNKNOWN
+  }
+
+  const requestedAtUnixMilliseconds = Date.parse(requestedAtIso)
+  if (Number.isNaN(requestedAtUnixMilliseconds)) {
+    return SummaryDataStatus.UNKNOWN
+  }
+
+  const loadingDurationMilliseconds = Date.now() - requestedAtUnixMilliseconds
+  if (loadingDurationMilliseconds > MAX_LOADING_STATE_AGE_MILLISECONDS) {
+    return SummaryDataStatus.UNKNOWN
+  }
+
+  return SummaryDataStatus.LOADING
 }
 
 /**
@@ -36,6 +58,7 @@ export function reduceSummaryData(summaryData, event) {
         patch: {
           status: SummaryDataStatus.LOADING,
           effort: event.effort,
+          requestedAt: event.requestedAt,
           errorMessage: null,
         },
       }
@@ -47,6 +70,7 @@ export function reduceSummaryData(summaryData, event) {
           markdown: event.markdown,
           effort: event.effort,
           checkedAt: event.checkedAt,
+          requestedAt: null,
           errorMessage: null,
         },
       }
@@ -55,6 +79,7 @@ export function reduceSummaryData(summaryData, event) {
         state: SummaryDataStatus.ERROR,
         patch: {
           status: SummaryDataStatus.ERROR,
+          requestedAt: null,
           errorMessage: event.errorMessage,
         },
       }
@@ -65,6 +90,7 @@ export function reduceSummaryData(summaryData, event) {
           status: SummaryDataStatus.UNKNOWN,
           markdown: '',
           errorMessage: null,
+          requestedAt: null,
           checkedAt: null,
         },
       }
@@ -75,6 +101,7 @@ export function reduceSummaryData(summaryData, event) {
           status: SummaryDataStatus.UNKNOWN,
           markdown: '',
           errorMessage: null,
+          requestedAt: null,
           checkedAt: null,
         },
       }

--- a/storage_service.py
+++ b/storage_service.py
@@ -53,36 +53,6 @@ def get_daily_payload(date):
         return result.data[0]['payload']
     return None
 
-def _sanitize_loading_states(payload):
-    """Reset any transient 'loading' summary/tldr states to 'unknown' before persisting.
-
-    'loading' is an ephemeral in-flight client state. If persisted (e.g. browser
-    closed mid-request), the article card gets stuck showing the spinner forever
-    on next load with no request to complete it.
-    """
-    articles = payload.get('articles')
-    if not articles:
-        return payload
-
-    new_articles = []
-    any_changed = False
-    for article in articles:
-        changed = False
-        for field in ('summary', 'tldr'):
-            data = article.get(field)
-            if isinstance(data, dict) and data.get('status') == 'loading':
-                if not changed:
-                    article = dict(article)
-                    changed = True
-                article[field] = {**data, 'status': 'unknown'}
-        new_articles.append(article)
-        any_changed = any_changed or changed
-
-    if not any_changed:
-        return payload
-    return {**payload, 'articles': new_articles}
-
-
 def set_daily_payload(date, payload):
     """
     Save or update daily payload (upsert).
@@ -96,7 +66,7 @@ def set_daily_payload(date, payload):
     supabase = supabase_client.get_supabase_client()
     result = supabase.table('daily_cache').upsert({
         'date': date,
-        'payload': _sanitize_loading_states(payload)
+        'payload': payload
     }).execute()
 
     return result.data[0] if result.data else None


### PR DESCRIPTION
### Motivation

- Avoid mutating user-provided payloads server-side by removing the automatic reset of transient `loading` states before persistence.

### Description

- Remove the `_sanitize_loading_states` helper that converted `summary`/`tldr` fields with `status: 'loading'` into `status: 'unknown'`.
- Update `set_daily_payload` to upsert the provided `payload` directly without sanitization.
- Leave scrape-path function `set_daily_payload_from_scrape` unchanged so `cached_at` is still updated for scrape freshness.

### Testing

- Ran unit tests for storage handling (`pytest tests/test_storage_service.py`) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0dc36b1c883328e52d442ce1289b5)