### PR TITLE
Add atomic single-article patch API and client optimistic patch path (RPC-backed)

### DIFF
--- a/client/src/hooks/useArticleState.js
+++ b/client/src/hooks/useArticleState.js
@@ -39,20 +39,17 @@ export function useArticleState(date, url) {
 
     const persistPatch = async () => {
       let latestPayload = optimisticPayload
-      let latestArticle = latestPayload.articles.find((currentArticle) => currentArticle.url === url)
       let latestPatch = optimisticPatch
       let expectedUpdatedAt = latestPayload.storage_updated_at
 
       for (let attemptIndex = 0; attemptIndex < 2; attemptIndex += 1) {
-        if (!latestArticle) throw new Error(`Article not found for url: ${url}`)
         if (!expectedUpdatedAt) {
           const storageRow = await getDailyPayloadWithMetadata(date)
           if (!storageRow) throw new Error(`Daily payload not found for date: ${date}`)
           latestPayload = storageRow.payload
           expectedUpdatedAt = storageRow.updatedAt
-          latestArticle = latestPayload.articles.find((currentArticle) => currentArticle.url === url)
+          const latestArticle = latestPayload.articles.find((currentArticle) => currentArticle.url === url)
           if (!latestArticle) throw new Error(`Article not found for url: ${url}`)
-          latestPatch = updater(latestArticle)
           setStorageValueInMemory(storageKey, applyArticlePatchToPayload(latestPayload, url, latestPatch))
         }
 
@@ -73,9 +70,8 @@ export function useArticleState(date, url) {
 
         latestPayload = patchResult.payload
         expectedUpdatedAt = patchResult.updatedAt
-        latestArticle = latestPayload.articles.find((currentArticle) => currentArticle.url === url)
+        const latestArticle = latestPayload.articles.find((currentArticle) => currentArticle.url === url)
         if (!latestArticle) throw new Error(`Article not found for url: ${url}`)
-        latestPatch = updater(latestArticle)
         setStorageValueInMemory(storageKey, applyArticlePatchToPayload(latestPayload, url, latestPatch))
       }
 

--- a/client/src/hooks/useArticleState.js
+++ b/client/src/hooks/useArticleState.js
@@ -1,15 +1,26 @@
 import { logTransition } from '../lib/stateTransitionLogger'
+import { getDailyPayloadWithMetadata, patchDailyArticle } from '../lib/storageApi'
 import { getNewsletterScrapeKey } from '../lib/storageKeys'
 import {
   ArticleLifecycleEventType,
   getArticleLifecycleState,
   reduceArticleLifecycle
 } from '../reducers/articleLifecycleReducer'
-import { useSupabaseStorage } from './useSupabaseStorage'
+import { setStorageValueInMemory, useSupabaseStorage } from './useSupabaseStorage'
+
+function applyArticlePatchToPayload(payload, url, articlePatch) {
+  if (!payload) return payload
+  return {
+    ...payload,
+    articles: payload.articles.map((article) =>
+      article.url === url ? { ...article, ...articlePatch } : article
+    )
+  }
+}
 
 export function useArticleState(date, url) {
   const storageKey = getNewsletterScrapeKey(date)
-  const [payload, setPayload, , { loading, error }] = useSupabaseStorage(storageKey, null)
+  const [payload, , , { loading, error }] = useSupabaseStorage(storageKey, null)
 
   const article = payload?.articles?.find(a => a.url === url) || null
 
@@ -19,16 +30,61 @@ export function useArticleState(date, url) {
 
   const updateArticle = (updater) => {
     if (!article) return
+    const previousPayload = payload
+    const optimisticPatch = updater(article)
+    if (!optimisticPatch || Object.keys(optimisticPatch).length === 0) return
 
-    setPayload(current => {
-      if (!current) return current
+    const optimisticPayload = applyArticlePatchToPayload(previousPayload, url, optimisticPatch)
+    setStorageValueInMemory(storageKey, optimisticPayload)
 
-      return {
-        ...current,
-        articles: current.articles.map(a =>
-          a.url === url ? { ...a, ...updater(a) } : a
-        )
+    const persistPatch = async () => {
+      let latestPayload = optimisticPayload
+      let latestArticle = latestPayload.articles.find((currentArticle) => currentArticle.url === url)
+      let latestPatch = optimisticPatch
+      let expectedUpdatedAt = latestPayload.storage_updated_at
+
+      for (let attemptIndex = 0; attemptIndex < 2; attemptIndex += 1) {
+        if (!latestArticle) throw new Error(`Article not found for url: ${url}`)
+        if (!expectedUpdatedAt) {
+          const storageRow = await getDailyPayloadWithMetadata(date)
+          if (!storageRow) throw new Error(`Daily payload not found for date: ${date}`)
+          latestPayload = storageRow.payload
+          expectedUpdatedAt = storageRow.updatedAt
+          latestArticle = latestPayload.articles.find((currentArticle) => currentArticle.url === url)
+          if (!latestArticle) throw new Error(`Article not found for url: ${url}`)
+          latestPatch = updater(latestArticle)
+          setStorageValueInMemory(storageKey, applyArticlePatchToPayload(latestPayload, url, latestPatch))
+        }
+
+        const patchResult = await patchDailyArticle(date, {
+          url,
+          patch: latestPatch,
+          expectedUpdatedAt
+        })
+
+        if (patchResult.success) {
+          setStorageValueInMemory(storageKey, patchResult.payload)
+          return
+        }
+
+        if (!patchResult.conflict) {
+          throw new Error('Daily article patch failed')
+        }
+
+        latestPayload = patchResult.payload
+        expectedUpdatedAt = patchResult.updatedAt
+        latestArticle = latestPayload.articles.find((currentArticle) => currentArticle.url === url)
+        if (!latestArticle) throw new Error(`Article not found for url: ${url}`)
+        latestPatch = updater(latestArticle)
+        setStorageValueInMemory(storageKey, applyArticlePatchToPayload(latestPayload, url, latestPatch))
       }
+
+      throw new Error('Daily article patch conflict retry exhausted')
+    }
+
+    persistPatch().catch((persistError) => {
+      console.error(`Failed to update article for ${url}:`, persistError)
+      setStorageValueInMemory(storageKey, previousPayload)
     })
   }
 

--- a/client/src/hooks/useSupabaseStorage.js
+++ b/client/src/hooks/useSupabaseStorage.js
@@ -157,6 +157,14 @@ export async function setStorageValueAsync(key, nextValue, defaultValue = null) 
   }
 }
 
+export function setStorageValueInMemory(key, nextValue) {
+  const previous = readCache.get(key)
+  const resolved = typeof nextValue === 'function' ? nextValue(previous) : nextValue
+  if (resolved === previous) return
+  readCache.set(key, resolved)
+  emitChange(key)
+}
+
 export function useSupabaseStorage(key, defaultValue) {
   // ─────────────────────────────────────────────────────────────────────────────
   // Cache Seeding for Scrape-First Hydration

--- a/client/src/lib/storageApi.js
+++ b/client/src/lib/storageApi.js
@@ -20,6 +20,20 @@ async function getDailyPayload(date) {
   return null
 }
 
+export async function getDailyPayloadWithMetadata(date) {
+  const response = await window.fetch(`/api/storage/daily/${date}`)
+  const data = await response.json()
+
+  if (!data.success) {
+    return null
+  }
+
+  return {
+    payload: data.payload,
+    updatedAt: data.updated_at
+  }
+}
+
 async function setDailyPayload(date, payload) {
   const response = await window.fetch(`/api/storage/daily/${date}`, {
     method: 'POST',
@@ -34,6 +48,39 @@ async function setDailyPayload(date, payload) {
   }
 
   return data.data
+}
+
+export async function patchDailyArticle(date, { url, patch, expectedUpdatedAt }) {
+  const response = await window.fetch(`/api/storage/daily/${date}/article`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      url,
+      patch,
+      expected_updated_at: expectedUpdatedAt
+    })
+  })
+
+  const data = await response.json()
+
+  if (response.status === 409) {
+    return {
+      success: false,
+      conflict: true,
+      payload: data.payload,
+      updatedAt: data.updated_at
+    }
+  }
+
+  if (!data.success) {
+    throw new Error(data.error || 'Failed to patch article')
+  }
+
+  return {
+    success: true,
+    payload: data.payload,
+    updatedAt: data.updated_at
+  }
 }
 
 export async function getDailyPayloadsRange(startDate, endDate, signal) {

--- a/scripts/setup/create_patch_daily_article_function.sql
+++ b/scripts/setup/create_patch_daily_article_function.sql
@@ -14,16 +14,23 @@ as $$
 declare
   current_payload jsonb;
   current_updated_at text;
+  current_updated_at_timestamp timestamptz;
+  expected_updated_at_timestamp timestamptz;
   article_index integer;
   patch_key text;
   patch_value jsonb;
   patched_payload jsonb;
   next_updated_at text;
 begin
+  expected_updated_at_timestamp := expected_updated_at::timestamptz;
   select
     daily_cache.payload,
-    coalesce(daily_cache.payload->>'storage_updated_at', daily_cache.cached_at::text)
-  into current_payload, current_updated_at
+    to_char(
+      coalesce((daily_cache.payload->>'storage_updated_at')::timestamptz, daily_cache.cached_at) at time zone 'UTC',
+      'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"'
+    ),
+    coalesce((daily_cache.payload->>'storage_updated_at')::timestamptz, daily_cache.cached_at)
+  into current_payload, current_updated_at, current_updated_at_timestamp
   from daily_cache
   where daily_cache.date = target_date;
 
@@ -31,7 +38,7 @@ begin
     raise exception 'daily_cache row not found for date %', target_date;
   end if;
 
-  if current_updated_at <> expected_updated_at then
+  if current_updated_at_timestamp <> expected_updated_at_timestamp then
     return query
       select true, current_payload, current_updated_at;
     return;
@@ -58,7 +65,10 @@ begin
     );
   end loop;
 
-  next_updated_at := now()::text;
+  next_updated_at := to_char(
+    now() at time zone 'UTC',
+    'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"'
+  );
   patched_payload := jsonb_set(
     patched_payload,
     '{storage_updated_at}',
@@ -70,7 +80,8 @@ begin
   set payload = patched_payload
   where
     daily_cache.date = target_date
-    and coalesce(daily_cache.payload->>'storage_updated_at', daily_cache.cached_at::text) = expected_updated_at;
+    and coalesce((daily_cache.payload->>'storage_updated_at')::timestamptz, daily_cache.cached_at)
+      = expected_updated_at_timestamp;
 
   if found then
     return query
@@ -80,7 +91,10 @@ begin
 
   select
     daily_cache.payload,
-    coalesce(daily_cache.payload->>'storage_updated_at', daily_cache.cached_at::text)
+    to_char(
+      coalesce((daily_cache.payload->>'storage_updated_at')::timestamptz, daily_cache.cached_at) at time zone 'UTC',
+      'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"'
+    )
   into current_payload, current_updated_at
   from daily_cache
   where daily_cache.date = target_date;

--- a/scripts/setup/create_patch_daily_article_function.sql
+++ b/scripts/setup/create_patch_daily_article_function.sql
@@ -1,0 +1,91 @@
+create or replace function public.patch_daily_article(
+  target_date date,
+  article_url text,
+  article_patch jsonb,
+  expected_updated_at text
+)
+returns table (
+  conflict boolean,
+  payload jsonb,
+  updated_at text
+)
+language plpgsql
+as $$
+declare
+  current_payload jsonb;
+  current_updated_at text;
+  article_index integer;
+  patch_key text;
+  patch_value jsonb;
+  patched_payload jsonb;
+  next_updated_at text;
+begin
+  select
+    daily_cache.payload,
+    coalesce(daily_cache.payload->>'storage_updated_at', daily_cache.cached_at::text)
+  into current_payload, current_updated_at
+  from daily_cache
+  where daily_cache.date = target_date;
+
+  if current_payload is null then
+    raise exception 'daily_cache row not found for date %', target_date;
+  end if;
+
+  if current_updated_at <> expected_updated_at then
+    return query
+      select true, current_payload, current_updated_at;
+    return;
+  end if;
+
+  select (article_entry.ordinality - 1)::integer
+  into article_index
+  from jsonb_array_elements(current_payload->'articles') with ordinality as article_entry(article, ordinality)
+  where article_entry.article->>'url' = article_url
+  limit 1;
+
+  if article_index is null then
+    raise exception 'article not found for url %', article_url;
+  end if;
+
+  patched_payload := current_payload;
+  for patch_key, patch_value in select key, value from jsonb_each(article_patch)
+  loop
+    patched_payload := jsonb_set(
+      patched_payload,
+      array['articles', article_index::text, patch_key],
+      patch_value,
+      true
+    );
+  end loop;
+
+  next_updated_at := now()::text;
+  patched_payload := jsonb_set(
+    patched_payload,
+    '{storage_updated_at}',
+    to_jsonb(next_updated_at),
+    true
+  );
+
+  update daily_cache
+  set payload = patched_payload
+  where
+    daily_cache.date = target_date
+    and coalesce(daily_cache.payload->>'storage_updated_at', daily_cache.cached_at::text) = expected_updated_at;
+
+  if found then
+    return query
+      select false, patched_payload, next_updated_at;
+    return;
+  end if;
+
+  select
+    daily_cache.payload,
+    coalesce(daily_cache.payload->>'storage_updated_at', daily_cache.cached_at::text)
+  into current_payload, current_updated_at
+  from daily_cache
+  where daily_cache.date = target_date;
+
+  return query
+    select true, current_payload, current_updated_at;
+end;
+$$;

--- a/serve.py
+++ b/serve.py
@@ -204,11 +204,60 @@ def set_storage_setting(key):
 def get_storage_daily(date):
     """Get cached payload for a specific date."""
     try:
-        payload = storage_service.get_daily_payload(date)
-        if payload is None:
+        row = storage_service.get_daily_payload_row(date)
+        if row is None:
             return jsonify({"success": False, "error": "Date not found"}), 404
 
-        return jsonify({"success": True, "payload": payload})
+        return jsonify({
+            "success": True,
+            "payload": row["payload"],
+            "updated_at": row["updated_at"],
+        })
+
+    except Exception as e:
+        logger.error(
+            "error date=%s error=%s",
+            date, repr(e),
+            exc_info=True,
+        )
+        return jsonify({"success": False, "error": repr(e)}), 500
+
+
+@app.route("/api/storage/daily/<date>/article", methods=["PATCH"])
+def patch_storage_daily_article(date):
+    """Patch a single article within a daily payload with optimistic concurrency."""
+    try:
+        data = request.get_json()
+        if not isinstance(data, dict):
+            return jsonify({"success": False, "error": "Invalid JSON body"}), 400
+        for key in ['url', 'patch', 'expected_updated_at']:
+            if key not in data:
+                return jsonify({"success": False, "error": f"Missing required field: {key}"}), 400
+        if not isinstance(data['patch'], dict):
+            return jsonify({"success": False, "error": "Field 'patch' must be an object"}), 400
+        if not data['patch']:
+            return jsonify({"success": False, "error": "Field 'patch' must not be empty"}), 400
+
+        rpc_result = storage_service.patch_daily_article(
+            date,
+            data['url'],
+            data['patch'],
+            data['expected_updated_at'],
+        )
+
+        if rpc_result.get('conflict'):
+            return jsonify({
+                "success": False,
+                "conflict": True,
+                "payload": rpc_result.get('payload'),
+                "updated_at": rpc_result.get('updated_at'),
+            }), 409
+
+        return jsonify({
+            "success": True,
+            "payload": rpc_result.get('payload'),
+            "updated_at": rpc_result.get('updated_at'),
+        })
 
     except Exception as e:
         logger.error(

--- a/storage_service.py
+++ b/storage_service.py
@@ -53,6 +53,21 @@ def get_daily_payload(date):
         return result.data[0]['payload']
     return None
 
+
+def get_daily_payload_row(date):
+    """Get payload and optimistic concurrency timestamp for a specific date."""
+    supabase = supabase_client.get_supabase_client()
+    result = supabase.table('daily_cache').select('payload, cached_at').eq('date', date).execute()
+    if not result.data:
+        return None
+    row = result.data[0]
+    payload = row['payload']
+    updated_at = payload.get('storage_updated_at') or row['cached_at']
+    return {
+        'payload': payload,
+        'updated_at': updated_at,
+    }
+
 def set_daily_payload(date, payload):
     """
     Save or update daily payload (upsert).
@@ -123,6 +138,23 @@ def is_date_cached(date):
     result = supabase.table('daily_cache').select('date').eq('date', date).execute()
 
     return len(result.data) > 0
+
+
+def patch_daily_article(date, url, patch, expected_updated_at):
+    """Atomically patch one article in daily_cache payload using RPC."""
+    supabase = supabase_client.get_supabase_client()
+    result = supabase.rpc(
+        'patch_daily_article',
+        {
+            'target_date': date,
+            'article_url': url,
+            'article_patch': patch,
+            'expected_updated_at': expected_updated_at,
+        },
+    ).execute()
+    if not result.data:
+        raise RuntimeError("patch_daily_article RPC returned no rows")
+    return result.data[0]
 
 
 def get_digest(digest_id: str) -> dict | None:


### PR DESCRIPTION
### Motivation
- Concurrent single-article updates were clobbering the whole-day JSONB payload because the client wrote the full `payload.articles` array on every update, causing read-modify-write races.  
- Introduce a minimal Supabase-aligned patch API that updates only one article atomically in SQL to reduce race surfaces and allow optimistic client updates with conflict detection and retry.  

### Description
- Add `GET /api/storage/daily/<date>` to return `{ payload, updated_at }` via `storage_service.get_daily_payload_row()` so clients can obtain a concurrency token, and add `PATCH /api/storage/daily/<date>/article` to accept `{ url, patch, expected_updated_at }` and call `storage_service.patch_daily_article(...)` which invokes the Supabase RPC.  
- Implement `storage_service.get_daily_payload_row()` and `storage_service.patch_daily_article()` as a wrapper for the RPC, and add SQL script `scripts/setup/create_patch_daily_article_function.sql` that implements `public.patch_daily_article(...)` performing an atomic JSONB `jsonb_set` article patch with optimistic concurrency and informative conflict return.  
- Client-side: add `getDailyPayloadWithMetadata` and `patchDailyArticle` in `client/src/lib/storageApi.js`, add `setStorageValueInMemory` to `useSupabaseStorage` for in-memory optimistic updates, and rework `useArticleState.updateArticle` to apply an optimistic in-memory patch then persist via the patch RPC with a single conflict retry and rollback on terminal failure.  
- Preserve existing full-payload write path for scrape/bootstrap flows; the new patch route is intended only for single-article user-state updates (summary/read/removed) to reduce clobber risk.  

### Testing
- Ran unit tests with `PYTHONPATH=. uv run pytest tests/test_scrape_cache_server.py` and they passed (`3 passed`).  
- Verified Python modules compile with `uv run python3 -m py_compile serve.py storage_service.py` with no syntax errors.  
- Built the client with `npm install` and `npm run build` successfully to ensure client-side changes integrate.  
- Reproduced the baseline full-payload clobber by simulating concurrent summarize/write flows (12 requests over 3s) to confirm the race (observed final counts showing overwrite), and attempted end-to-end verification of the new RPC path but the Supabase RPC could not be exercised from this environment because the `patch_daily_article` function is not yet deployed in the Supabase schema cache and direct DB apply from this environment failed due to network reachability; the new endpoint and client retry logic are wired and ready once the SQL function is deployed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e238c66808833288c93efce2022be9)