### PR TITLE
feat: replace context menu placeholders with Elaborate action

### DIFF
--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -1,9 +1,21 @@
 ---
-last_updated: 2026-02-17 08:01, c62aa7b
+last_updated: 2026-04-24 06:28
 ---
 # Gotchas
 
 This document catalogs recurring pitfalls in various topics, including managing client-side state persistence and reactivity, surprising design decisions, and so on.
+
+---
+
+#### 2026-04-20: Portal clicks bubble through React tree and ghost-click underlying components
+
+**Desired behavior that didn't work**: Tapping "Elaborate" in the context menu should start the elaboration fetch and keep the ZenModeOverlay open.
+
+**What actually happened**: The overlay closed immediately after the fetch started. Logs showed `[summary-view] expanded → collapsed` 9ms after the action click, aborting the in-flight fetch.
+
+**Cause & Fix**: React portals render into a different DOM node but events still bubble through the **React component tree**. `OverlayContextMenu` is a portal but is a React child of `ZenModeOverlay` → `ArticleCard`. The click on the menu button bubbled up to `ArticleCard`'s `onClick={handleCardClick}`. By then, `removeAllRanges()` had already cleared the selection, so the `if (selection.toString().length > 0) return` guard didn't fire, and `summary.toggle()` → `collapse()` closed the overlay. `BaseOverlay` already had `onClick={(e) => e.stopPropagation()}` for this reason. Adding the same to `OverlayContextMenu` and `ElaborationPreview` fixed it.
+
+**The generalized principle**: every portal that is a React descendant of a click-handling ancestor needs `onClick={e => e.stopPropagation()}` on its root, or clicks will silently reach ancestors via React's synthetic event bubbling regardless of DOM structure.
 
 ---
 

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -38,6 +38,9 @@ last_updated: 2026-04-23 11:53
 │     ├── simplify-code
 │     │  └── SKILL.md
 │     ├── supabase-postgres-best-practices
+│     ├── terse-output
+│     │  ├── metadata.yaml
+│     │  └── SKILL.md
 │     ├── to-done
 │     │  └── SKILL.md
 │     ├── vercel
@@ -221,6 +224,7 @@ last_updated: 2026-04-23 11:53
 ├── README.md
 ├── requirements.txt
 ├── serve.py
+├── sessions.yaml
 ├── setup.sh
 ├── shopping_cart_service.py
 ├── source_routes.py

--- a/client/STATE_MACHINES.md
+++ b/client/STATE_MACHINES.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-04-18 09:26, 529852a
+last_updated: 2026-04-24 06:29
 scope: a well defined yet deep view of all the client state machines
 ---
 # Client State Machines
@@ -842,50 +842,66 @@ Clicking a toast calls `onOpen()` (expands the summary overlay) then dismisses i
 
 | | |
 |---|---|
-| **Pattern** | `useState` + `useRef` + document-level event listeners (capture phase) |
+| **Pattern** | `useState` + synchronously-mirrored `useRef` + three private hooks coordinating document-level event listeners (capture phase) |
 | **Files** | `hooks/useOverlayContextMenu.js`, `components/OverlayContextMenu.jsx` |
 | **Scope** | Per-overlay instance (one per `ZenModeOverlay` / `DigestOverlay`) |
 | **Status** | WIP — mobile selection interactions still buggy (pending concrete bug list). Debug instrumentation (`[ctxmenu]` console.logs + `quakeConsole.js` heartbeat) is intentionally left in. |
 
+#### Internal Composition
+
+The exported `useOverlayContextMenu` is a thin coordinator that composes three private hooks in the same file:
+
+- `useDesktopContextMenu({ enabled, openMenu })` — owns `onContextMenu` (desktop right-click) only.
+- `useMobileSelectionMenu({ enabled, openMenu, closeMenu, menuStateRef })` — owns `selectionchange` / `touchstart` / `touchend` (mobile native text selection) only.
+- `useOverlayMenuDismissal({ isOpen, menuRef, closeMenu, menuStateRef })` — owns outside `pointerdown` and capture-phase Escape only.
+
+The split replaces the previous monolithic hook. Desktop right-click and mobile selection are now independent paths that do not share close semantics except via the shared `closeMenu` command.
+
 #### State Shape
 
 ```js
-{ isOpen: false, anchorX: 0, anchorY: 0 }
+{ isOpen: false, anchorX: 0, anchorY: 0, selectedText: '', source: 'none' }
+// source ∈ { 'none', 'desktop', 'mobile-selection' }   (MenuOpenSource)
 // plus two refs:
 menuRef                  // attached to the portal's root div; used for "click inside menu" test
-openedBySelectionRef     // which open path fired — drives whether closing clears the window selection
+menuStateRef             // mirrors menuState so capture-phase document listeners can read the
+                         // current `source` without reattaching. Mutated synchronously inside
+                         // openMenu()/closeMenu() so it is authoritative even before React commits;
+                         // a useEffect also mirrors post-commit as a backstop.
 ```
+
+`source` is internal coordination state — it is **not** exposed from the hook's return value.
 
 #### States
 
 ```
-CLOSED  ──(right-click in overlay content)──►  OPEN_BY_CLICK
-CLOSED  ──(mobile: selection settled in [data-overlay-content] after touchend)──►  OPEN_BY_SELECTION
-OPEN_*  ──(outside pointerdown / Escape / selection cleared / enabled→false)──►  CLOSED
+CLOSED  ──(right-click in overlay content)──►  OPEN (source=desktop)
+CLOSED  ──(mobile: selection settled in [data-overlay-content] after touchend)──►  OPEN (source=mobile-selection)
+OPEN    ──(outside pointerdown / Escape / selection cleared / enabled→false)──►  CLOSED
 ```
 
-`openedBySelectionRef` is the discriminator. On close:
-- If `true` (selection path): call `window.getSelection()?.removeAllRanges()` before closing.
-- If `false` (click path): do not touch the selection.
+`menuStateRef.current.source` is the discriminator. On close:
+- If `source === 'mobile-selection'` (via `closeMenu({ clearSelection: true })` from outside-pointerdown): call `window.getSelection()?.removeAllRanges()` before closing.
+- Otherwise: do not touch the selection.
 
-This ref is reset to `false` inside both `closeMenu()` and `handleContextMenu()` — the right-click path must declare `false` authoritatively, otherwise a previous selection-open can leak its "owned the selection" flag into a subsequent right-click open.
+Because `source` lives inside `menuState` (not a standalone ref), the right-click and mobile-selection paths can't leak their flag into each other — every `openMenu` call declares `source` authoritatively.
 
 #### Events / Transitions
 
 | Event | Source | Effect |
 |---|---|---|
-| `onContextMenu` on scroll surface | `BaseOverlay.onContentContextMenu` (desktop right-click) | `preventDefault`; `openedBySelectionRef=false`; set `{isOpen, anchorX: clientX, anchorY: clientY}` |
-| `touchend` (capture, document) | mobile finger lift | If a non-empty selection exists whose `anchorNode.parentElement.closest('[data-overlay-content]')` matches → `openedBySelectionRef=true`; set menu anchored at the selection rect's bottom-center |
-| `selectionchange` (document) | mobile selection handles | If collapsed/empty and `openedBySelectionRef` → `closeMenu`. If populated and `!touchActive` → `openMenuFromSelection` |
-| `touchstart`/`touchend` (capture) | mobile | Toggle `touchActive` — gates `selectionchange` so the menu opens on finger lift rather than mid-gesture |
-| `pointerdown` (capture, document, only while open) | outside click | If outside `menuRef`: clear selection iff `openedBySelectionRef`, then `closeMenu` |
-| `keydown: Escape` (capture, document, only while open) | keyboard | `preventDefault + stopPropagation + stopImmediatePropagation`; `closeMenu`. The `defaultPrevented` flag is the backstop `BaseOverlay` checks to avoid also closing the overlay |
-| `enabled → false` | hook prop | `closeMenu` |
+| `onContextMenu` on scroll surface | `useDesktopContextMenu` (via `BaseOverlay.onContentContextMenu`, desktop right-click) | `preventDefault`; `openMenu({ source: 'desktop', anchorX: clientX, anchorY: clientY })` |
+| `touchend` (capture, document) | `useMobileSelectionMenu` (mobile finger lift) | If a non-empty selection exists whose `anchorNode.parentElement.closest('[data-overlay-content]')` matches → `openMenu({ source: 'mobile-selection', ...selectionRect })` |
+| `selectionchange` (document) | `useMobileSelectionMenu` (mobile selection handles) | If collapsed/empty and `menuStateRef.current.source === 'mobile-selection'` and `!touchActive` → `closeMenu()`. If populated and `!touchActive` → open from selection |
+| `touchstart`/`touchend` (capture) | `useMobileSelectionMenu` | Toggle local `touchActive` — gates `selectionchange` so the menu opens on finger lift rather than mid-gesture |
+| `pointerdown` (capture, document, only while open) | `useOverlayMenuDismissal` (outside click) | If outside `menuRef`: `closeMenu({ clearSelection: menuStateRef.current.source === 'mobile-selection' })` |
+| `keydown: Escape` (capture, document, only while open) | `useOverlayMenuDismissal` (keyboard) | `preventDefault + stopPropagation + stopImmediatePropagation`; `closeMenu()`. The `defaultPrevented` flag is the backstop `BaseOverlay` checks to avoid also closing the overlay |
+| `enabled → false` | coordinator effect | `closeMenu()` |
 | action button click | `OverlayContextMenu.handleActionClick` | Clear selection; `onClose()`; invoke `action.onSelect()` |
 
 #### DOM / Event Contracts (cooperating with BaseOverlay)
 
-1. **`data-overlay-content` marker** — `BaseOverlay` tags its scroll surface. The hook's mobile `openMenuFromSelection` bails unless the selection's `anchorNode.parentElement.closest('[data-overlay-content]')` matches. Removing the attribute turns every selection on the page into a menu trigger.
+1. **`data-overlay-content` marker** — `BaseOverlay` tags its scroll surface. `useMobileSelectionMenu`'s selection reader bails unless the selection's `anchorNode.parentElement.closest('[data-overlay-content]')` matches. Removing the attribute turns every selection on the page into a menu trigger.
 2. **Escape arbitration via `event.defaultPrevented`** — the hook's Escape handler calls `stopImmediatePropagation()` + `preventDefault()` on the capture phase; `BaseOverlay` returns early if `event.defaultPrevented`. Removing either side causes Escape to close both menu and overlay at once.
 
 Both contracts are commented at the use site (`useOverlayContextMenu.js` top-of-file block comment + `BaseOverlay.jsx` inline comments on the Escape handler and the `data-overlay-content` div).
@@ -909,7 +925,7 @@ Both contracts are commented at the use site (`useOverlayContextMenu.js` top-of-
 All tied to iOS / Android native selection UI; handled with care because the hook coexists with a non-React selection state machine in the browser:
 - Long-hold still vs. long-hold + drag vs. dragging selection handles to extend.
 - Tapping the already-selected range (usually collapses and may collide with `handlePointerDown`'s `getSelection().removeAllRanges()`).
-- Tapping a menu button while prose is still selected — `touchend` fires before `click`, so `openMenuFromSelection` can re-open the menu in the gap between `touchend` and the action's `handleActionClick` clearing the selection.
+- Tapping a menu button while prose is still selected — `touchend` fires before `click`, so `useMobileSelectionMenu`'s `openFromSelection` can re-open the menu in the gap between `touchend` and the action's `handleActionClick` clearing the selection.
 - Selections that start or end outside the viewport (`range.getBoundingClientRect()` may report off-screen coordinates; `clampMenuPosition` clamps but the anchor can feel disconnected).
 
 These are instrumented (the `[ctxmenu]` logs in every branch) pending a concrete bug report.

--- a/client/src/components/ArticleCard.jsx
+++ b/client/src/components/ArticleCard.jsx
@@ -225,6 +225,7 @@ function ArticleCard({ article }) {
               <ZenModeOverlay
                 url={fullUrl}
                 html={summary.html}
+                summaryMarkdown={summary.markdown}
                 hostname={hostname}
                 displayDomain={displayDomain}
                 articleMeta={article.articleMeta}

--- a/client/src/components/DigestOverlay.jsx
+++ b/client/src/components/DigestOverlay.jsx
@@ -1,58 +1,27 @@
-import { BookOpen, Check, ChevronDown } from 'lucide-react'
-import { useOverlayContextMenu } from '../hooks/useOverlayContextMenu'
+import { BookOpen } from 'lucide-react'
 import BaseOverlay, { overlayProseClassName } from './BaseOverlay'
-import OverlayContextMenu from './OverlayContextMenu'
 
 function DigestOverlay({ html, expanded, articleCount, errorMessage, onClose, onMarkRemoved }) {
-  const contextMenu = useOverlayContextMenu(expanded)
-  const actions = [
-    {
-      key: 'close-reader',
-      label: 'Close reader',
-      icon: <ChevronDown size={15} />,
-      onSelect: onClose,
-    },
-    {
-      key: 'mark-done',
-      label: 'Mark done',
-      icon: <Check size={15} />,
-      onSelect: onMarkRemoved,
-      tone: 'success',
-    },
-  ]
-
   return (
-    <>
-      <BaseOverlay
-        expanded={expanded}
-        headerContent={(
-          <div className="flex items-center gap-2">
-            <BookOpen size={16} className="text-slate-500" />
-            <span className="text-sm text-slate-500 font-medium">
-              {articleCount} {articleCount === 1 ? 'article' : 'articles'}
-            </span>
-          </div>
-        )}
-        onClose={onClose}
-        onMarkRemoved={onMarkRemoved}
-        onContentContextMenu={contextMenu.handleContextMenu}
-      >
-        {errorMessage && !html ? (
-          <div className="text-sm text-red-500 bg-red-50 p-4 rounded-lg">{errorMessage}</div>
-        ) : (
-          <div className={overlayProseClassName} dangerouslySetInnerHTML={{ __html: html }} />
-        )}
-      </BaseOverlay>
-
-      <OverlayContextMenu
-        isOpen={contextMenu.isOpen}
-        anchorX={contextMenu.anchorX}
-        anchorY={contextMenu.anchorY}
-        actions={actions}
-        onClose={contextMenu.closeMenu}
-        menuRef={contextMenu.menuRef}
-      />
-    </>
+    <BaseOverlay
+      expanded={expanded}
+      headerContent={(
+        <div className="flex items-center gap-2">
+          <BookOpen size={16} className="text-slate-500" />
+          <span className="text-sm text-slate-500 font-medium">
+            {articleCount} {articleCount === 1 ? 'article' : 'articles'}
+          </span>
+        </div>
+      )}
+      onClose={onClose}
+      onMarkRemoved={onMarkRemoved}
+    >
+      {errorMessage && !html ? (
+        <div className="text-sm text-red-500 bg-red-50 p-4 rounded-lg">{errorMessage}</div>
+      ) : (
+        <div className={overlayProseClassName} dangerouslySetInnerHTML={{ __html: html }} />
+      )}
+    </BaseOverlay>
   )
 }
 

--- a/client/src/components/ElaborationPreview.jsx
+++ b/client/src/components/ElaborationPreview.jsx
@@ -1,0 +1,123 @@
+import { AnimatePresence, motion } from 'framer-motion'
+import { Sparkles, X } from 'lucide-react'
+import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { markdownToHtml } from '../lib/markdownUtils'
+import { overlayProseClassName } from './BaseOverlay'
+
+function SnippetEcho({ text }) {
+  if (!text) return null
+  const truncated = text.length > 120 ? `${text.slice(0, 120)}…` : text
+  return (
+    <p className="text-xs font-serif italic text-slate-500 leading-snug line-clamp-2">
+      “{truncated}”
+    </p>
+  )
+}
+
+function LoadingBody({ selectedText }) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 text-center">
+      <motion.div
+        animate={{ scale: [1, 1.08, 1], opacity: [0.7, 1, 0.7] }}
+        transition={{ duration: 1.6, repeat: Infinity, ease: 'easeInOut' }}
+        className="flex h-12 w-12 items-center justify-center rounded-full bg-brand-50 text-brand-500"
+      >
+        <Sparkles size={22} />
+      </motion.div>
+      <p className="text-sm font-medium text-slate-500">Elaborating…</p>
+      <div className="max-w-sm">
+        <SnippetEcho text={selectedText} />
+      </div>
+    </div>
+  )
+}
+
+function ErrorBody({ message }) {
+  return (
+    <div className="flex flex-1 items-center justify-center px-6">
+      <p className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-600">
+        {message || 'Elaboration failed. Try again.'}
+      </p>
+    </div>
+  )
+}
+
+function AvailableBody({ markdown, selectedText }) {
+  const html = markdownToHtml(markdown)
+  return (
+    <>
+      <div className="shrink-0 border-b border-slate-200/60 px-5 py-3">
+        <SnippetEcho text={selectedText} />
+      </div>
+      <div className="flex-1 overflow-y-auto px-5 py-4">
+        <div className={overlayProseClassName} dangerouslySetInnerHTML={{ __html: html }} />
+      </div>
+    </>
+  )
+}
+
+function ElaborationPreview({ isOpen, status, selectedText, markdown, errorMessage, onClose }) {
+  useEffect(() => {
+    if (!isOpen) return
+    function handleKeyDown(event) {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      event.stopPropagation()
+      onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown, true)
+    return () => document.removeEventListener('keydown', handleKeyDown, true)
+  }, [isOpen, onClose])
+
+  return createPortal(
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 z-[210] flex items-center justify-center"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.18 }}
+        >
+          <button
+            type="button"
+            aria-label="Dismiss elaboration"
+            className="absolute inset-0 bg-slate-900/30 backdrop-blur-sm"
+            onClick={onClose}
+          />
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Elaboration"
+            initial={{ opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.96 }}
+            transition={{ type: 'spring', stiffness: 320, damping: 28 }}
+            className="relative flex h-[60vh] w-[85vw] max-w-xl flex-col overflow-hidden rounded-3xl border border-white/60 bg-white/80 shadow-elevated backdrop-blur-2xl"
+          >
+            <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/80 to-transparent" />
+
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="absolute right-3 top-3 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-white/70 text-slate-500 shadow-card backdrop-blur transition-colors hover:bg-white hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-400/60"
+            >
+              <X size={15} />
+            </button>
+
+            {status === 'loading' && <LoadingBody selectedText={selectedText} />}
+            {status === 'error' && <ErrorBody message={errorMessage} />}
+            {status === 'available' && (
+              <AvailableBody markdown={markdown} selectedText={selectedText} />
+            )}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>,
+    document.body
+  )
+}
+
+export default ElaborationPreview

--- a/client/src/components/ElaborationPreview.jsx
+++ b/client/src/components/ElaborationPreview.jsx
@@ -75,6 +75,7 @@ function ElaborationPreview({ isOpen, status, selectedText, markdown, errorMessa
       {isOpen && (
         <motion.div
           className="fixed inset-0 z-[210] flex items-center justify-center"
+          onClick={(e) => e.stopPropagation()}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}

--- a/client/src/components/OverlayContextMenu.jsx
+++ b/client/src/components/OverlayContextMenu.jsx
@@ -17,7 +17,7 @@ function clampMenuPosition(anchorX, anchorY, actionCount) {
   }
 }
 
-function OverlayContextMenu({ isOpen, anchorX, anchorY, actions, onClose, menuRef }) {
+function OverlayContextMenu({ isOpen, anchorX, anchorY, actions, onClose, menuRef, selectedText }) {
   const firstActionRef = useRef(null)
 
   useEffect(() => {
@@ -33,10 +33,14 @@ function OverlayContextMenu({ isOpen, anchorX, anchorY, actions, onClose, menuRe
   function handleActionClick(action) {
     if (action.disabled) return
 
-    const selectedText = window.getSelection()?.toString() ?? ''
+    // Prefer the text captured at menu-open time; fall back to live selection.
+    // On mobile, touchstart may collapse the selection before click fires,
+    // so live getSelection() can return '' by the time this runs.
+    const text = selectedText || window.getSelection()?.toString() || ''
+    console.log('[ctxmenu] action click — key:', action.key, '| text:', text.slice(0, 40), '| live:', window.getSelection()?.toString()?.slice(0, 40))
     window.getSelection()?.removeAllRanges()
     onClose()
-    action.onSelect(selectedText)
+    action.onSelect(text)
   }
 
   return createPortal(
@@ -44,6 +48,7 @@ function OverlayContextMenu({ isOpen, anchorX, anchorY, actions, onClose, menuRe
       ref={menuRef}
       role="menu"
       aria-label="Reading actions"
+      onClick={(e) => e.stopPropagation()}
       onContextMenu={(event) => event.preventDefault()}
       className="fixed z-[150] w-[184px] overflow-hidden rounded-2xl border border-slate-200/80 bg-white/95 p-1.5 text-slate-700 shadow-elevated backdrop-blur-xl motion-safe:animate-overlay-menu-enter"
       style={{ left: position.left, top: position.top }}

--- a/client/src/components/OverlayContextMenu.jsx
+++ b/client/src/components/OverlayContextMenu.jsx
@@ -33,9 +33,10 @@ function OverlayContextMenu({ isOpen, anchorX, anchorY, actions, onClose, menuRe
   function handleActionClick(action) {
     if (action.disabled) return
 
+    const selectedText = window.getSelection()?.toString() ?? ''
     window.getSelection()?.removeAllRanges()
     onClose()
-    action.onSelect()
+    action.onSelect(selectedText)
   }
 
   return createPortal(

--- a/client/src/components/ZenModeOverlay.jsx
+++ b/client/src/components/ZenModeOverlay.jsx
@@ -1,29 +1,93 @@
 import { Sparkles } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
 import { useOverlayContextMenu } from '../hooks/useOverlayContextMenu'
 import BaseOverlay, { overlayProseClassName } from './BaseOverlay'
+import ElaborationPreview from './ElaborationPreview'
 import OverlayContextMenu from './OverlayContextMenu'
+
+const IDLE_ELABORATION = Object.freeze({
+  status: 'idle',
+  selectedText: '',
+  markdown: '',
+  errorMessage: '',
+})
 
 function ZenModeOverlay({ url, html, summaryMarkdown, hostname, displayDomain, articleMeta, onClose, onMarkRemoved }) {
   const contextMenu = useOverlayContextMenu(true)
+  const [elaboration, setElaboration] = useState(IDLE_ELABORATION)
+  const abortControllerRef = useRef(null)
+
   const truncatedMeta = articleMeta && articleMeta.length > 22
     ? `${articleMeta.slice(0, 22)}...`
     : articleMeta
+
+  useEffect(() => {
+    return () => abortControllerRef.current?.abort()
+  }, [])
+
+  function closeElaboration() {
+    abortControllerRef.current?.abort()
+    abortControllerRef.current = null
+    setElaboration(IDLE_ELABORATION)
+  }
+
+  async function runElaboration(selectedText) {
+    abortControllerRef.current?.abort()
+    const controller = new AbortController()
+    abortControllerRef.current = controller
+
+    setElaboration({ status: 'loading', selectedText, markdown: '', errorMessage: '' })
+
+    try {
+      const response = await window.fetch('/api/elaborate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url,
+          selected_text: selectedText,
+          summary_markdown: summaryMarkdown,
+        }),
+        signal: controller.signal,
+      })
+      const result = await response.json()
+      if (controller.signal.aborted) return
+
+      if (!response.ok || !result.success) {
+        setElaboration({
+          status: 'error',
+          selectedText,
+          markdown: '',
+          errorMessage: result.error || 'Failed to elaborate.',
+        })
+        return
+      }
+
+      setElaboration({
+        status: 'available',
+        selectedText,
+        markdown: result.elaboration_markdown,
+        errorMessage: '',
+      })
+    } catch (error) {
+      if (error.name === 'AbortError') return
+      setElaboration({
+        status: 'error',
+        selectedText,
+        markdown: '',
+        errorMessage: error.message || 'Failed to elaborate.',
+      })
+    }
+  }
+
   const actions = [
     {
       key: 'elaborate',
       label: 'Elaborate',
       icon: <Sparkles size={15} />,
       onSelect: (selectedText) => {
-        if (!selectedText.trim()) return
-        window.fetch('/api/elaborate', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            url,
-            selected_text: selectedText,
-            summary_markdown: summaryMarkdown,
-          }),
-        })
+        const trimmed = selectedText.trim()
+        if (!trimmed) return
+        runElaboration(trimmed)
       },
     },
   ]
@@ -65,6 +129,15 @@ function ZenModeOverlay({ url, html, summaryMarkdown, hostname, displayDomain, a
         actions={actions}
         onClose={contextMenu.closeMenu}
         menuRef={contextMenu.menuRef}
+      />
+
+      <ElaborationPreview
+        isOpen={elaboration.status !== 'idle'}
+        status={elaboration.status}
+        selectedText={elaboration.selectedText}
+        markdown={elaboration.markdown}
+        errorMessage={elaboration.errorMessage}
+        onClose={closeElaboration}
       />
     </>
   )

--- a/client/src/components/ZenModeOverlay.jsx
+++ b/client/src/components/ZenModeOverlay.jsx
@@ -1,26 +1,30 @@
-import { Check, ChevronDown } from 'lucide-react'
+import { Sparkles } from 'lucide-react'
 import { useOverlayContextMenu } from '../hooks/useOverlayContextMenu'
 import BaseOverlay, { overlayProseClassName } from './BaseOverlay'
 import OverlayContextMenu from './OverlayContextMenu'
 
-function ZenModeOverlay({ url, html, hostname, displayDomain, articleMeta, onClose, onMarkRemoved }) {
+function ZenModeOverlay({ url, html, summaryMarkdown, hostname, displayDomain, articleMeta, onClose, onMarkRemoved }) {
   const contextMenu = useOverlayContextMenu(true)
   const truncatedMeta = articleMeta && articleMeta.length > 22
     ? `${articleMeta.slice(0, 22)}...`
     : articleMeta
   const actions = [
     {
-      key: 'close-reader',
-      label: 'Close reader',
-      icon: <ChevronDown size={15} />,
-      onSelect: onClose,
-    },
-    {
-      key: 'mark-done',
-      label: 'Mark done',
-      icon: <Check size={15} />,
-      onSelect: onMarkRemoved,
-      tone: 'success',
+      key: 'elaborate',
+      label: 'Elaborate',
+      icon: <Sparkles size={15} />,
+      onSelect: (selectedText) => {
+        if (!selectedText.trim()) return
+        window.fetch('/api/elaborate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            url,
+            selected_text: selectedText,
+            summary_markdown: summaryMarkdown,
+          }),
+        })
+      },
     },
   ]
 

--- a/client/src/components/ZenModeOverlay.jsx
+++ b/client/src/components/ZenModeOverlay.jsx
@@ -36,9 +36,11 @@ function ZenModeOverlay({ url, html, summaryMarkdown, hostname, displayDomain, a
     const controller = new AbortController()
     abortControllerRef.current = controller
 
+    console.log('[elaborate] starting — text:', selectedText.slice(0, 60))
     setElaboration({ status: 'loading', selectedText, markdown: '', errorMessage: '' })
 
     try {
+      console.log('[elaborate] sending POST /api/elaborate')
       const response = await window.fetch('/api/elaborate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -49,10 +51,15 @@ function ZenModeOverlay({ url, html, summaryMarkdown, hostname, displayDomain, a
         }),
         signal: controller.signal,
       })
+      console.log('[elaborate] response received — status:', response.status, '| aborted:', controller.signal.aborted)
       const result = await response.json()
-      if (controller.signal.aborted) return
+      if (controller.signal.aborted) {
+        console.log('[elaborate] aborted after response — discarding')
+        return
+      }
 
       if (!response.ok || !result.success) {
+        console.log('[elaborate] error response —', result.error)
         setElaboration({
           status: 'error',
           selectedText,
@@ -62,6 +69,7 @@ function ZenModeOverlay({ url, html, summaryMarkdown, hostname, displayDomain, a
         return
       }
 
+      console.log('[elaborate] success — markdown length:', result.elaboration_markdown?.length)
       setElaboration({
         status: 'available',
         selectedText,
@@ -69,7 +77,11 @@ function ZenModeOverlay({ url, html, summaryMarkdown, hostname, displayDomain, a
         errorMessage: '',
       })
     } catch (error) {
-      if (error.name === 'AbortError') return
+      if (error.name === 'AbortError') {
+        console.log('[elaborate] fetch aborted')
+        return
+      }
+      console.log('[elaborate] fetch error —', error.message)
       setElaboration({
         status: 'error',
         selectedText,
@@ -86,6 +98,7 @@ function ZenModeOverlay({ url, html, summaryMarkdown, hostname, displayDomain, a
       icon: <Sparkles size={15} />,
       onSelect: (selectedText) => {
         const trimmed = selectedText.trim()
+        console.log('[elaborate] onSelect — raw:', JSON.stringify(selectedText.slice(0, 40)), '| trimmed:', JSON.stringify(trimmed.slice(0, 40)))
         if (!trimmed) return
         runElaboration(trimmed)
       },
@@ -129,6 +142,7 @@ function ZenModeOverlay({ url, html, summaryMarkdown, hostname, displayDomain, a
         actions={actions}
         onClose={contextMenu.closeMenu}
         menuRef={contextMenu.menuRef}
+        selectedText={contextMenu.selectedText}
       />
 
       <ElaborationPreview

--- a/client/src/hooks/useOverlayContextMenu.js
+++ b/client/src/hooks/useOverlayContextMenu.js
@@ -36,18 +36,24 @@ export function useOverlayContextMenu(enabled = true) {
   console.log('[ctxmenu] render — enabled:', enabled, '| isOpen:', menuState.isOpen)
 
   const openMenu = useCallback(({ source, anchorX, anchorY, selectedText = '' }) => {
-    setMenuState({
+    const nextState = {
       isOpen: true,
       anchorX,
       anchorY,
       selectedText,
       source,
-    })
+    }
+    // Mutate the ref synchronously so document listeners that fire between
+    // setState and React's commit still see the authoritative `source`.
+    // The useEffect mirror above is a backstop for any non-command path.
+    menuStateRef.current = nextState
+    setMenuState(nextState)
   }, [])
 
   const closeMenu = useCallback(({ clearSelection = false } = {}) => {
     console.log('[ctxmenu] closeMenu — clearSelection:', clearSelection, '| source:', menuStateRef.current.source)
     if (clearSelection) window.getSelection()?.removeAllRanges()
+    menuStateRef.current = CLOSED_MENU_STATE
     setMenuState(CLOSED_MENU_STATE)
   }, [])
 

--- a/client/src/hooks/useOverlayContextMenu.js
+++ b/client/src/hooks/useOverlayContextMenu.js
@@ -1,10 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+const MenuOpenSource = Object.freeze({
+  NONE: 'none',
+  DESKTOP: 'desktop',
+  MOBILE_SELECTION: 'mobile-selection',
+})
+
 const CLOSED_MENU_STATE = Object.freeze({
   isOpen: false,
   anchorX: 0,
   anchorY: 0,
   selectedText: '',
+  source: MenuOpenSource.NONE,
 })
 
 // CONTRACT — this hook pairs with two things that must cooperate:
@@ -20,30 +27,72 @@ const CLOSED_MENU_STATE = Object.freeze({
 export function useOverlayContextMenu(enabled = true) {
   const [menuState, setMenuState] = useState(CLOSED_MENU_STATE)
   const menuRef = useRef(null)
-  const openedBySelectionRef = useRef(false)
+  const menuStateRef = useRef(menuState)
+
+  useEffect(() => {
+    menuStateRef.current = menuState
+  }, [menuState])
 
   console.log('[ctxmenu] render — enabled:', enabled, '| isOpen:', menuState.isOpen)
 
-  const closeMenu = useCallback(() => {
-    console.log('[ctxmenu] closeMenu — openedBySelection:', openedBySelectionRef.current)
-    openedBySelectionRef.current = false
+  const openMenu = useCallback(({ source, anchorX, anchorY, selectedText = '' }) => {
+    setMenuState({
+      isOpen: true,
+      anchorX,
+      anchorY,
+      selectedText,
+      source,
+    })
+  }, [])
+
+  const closeMenu = useCallback(({ clearSelection = false } = {}) => {
+    console.log('[ctxmenu] closeMenu — clearSelection:', clearSelection, '| source:', menuStateRef.current.source)
+    if (clearSelection) window.getSelection()?.removeAllRanges()
     setMenuState(CLOSED_MENU_STATE)
   }, [])
 
-  const handleContextMenu = useCallback((event) => {
+  const handleContextMenu = useDesktopContextMenu({ enabled, openMenu })
+  useMobileSelectionMenu({ enabled, openMenu, closeMenu, menuStateRef })
+  useOverlayMenuDismissal({
+    isOpen: menuState.isOpen,
+    menuRef,
+    closeMenu,
+    menuStateRef,
+  })
+
+  useEffect(() => {
+    if (enabled) return
+    closeMenu()
+  }, [closeMenu, enabled])
+
+  return {
+    isOpen: menuState.isOpen,
+    anchorX: menuState.anchorX,
+    anchorY: menuState.anchorY,
+    selectedText: menuState.selectedText,
+    menuRef,
+    handleContextMenu,
+    closeMenu,
+  }
+}
+
+function useDesktopContextMenu({ enabled, openMenu }) {
+  return useCallback((event) => {
     console.log('[ctxmenu] handleContextMenu — enabled:', enabled, '| target:', event.target.tagName)
     if (!enabled) return
 
     event.preventDefault()
-    openedBySelectionRef.current = false
-    setMenuState({
-      isOpen: true,
+    openMenu({
+      source: MenuOpenSource.DESKTOP,
       anchorX: event.clientX,
       anchorY: event.clientY,
+      selectedText: '',
     })
     console.log('[ctxmenu] opened via right-click at', event.clientX, event.clientY)
-  }, [enabled])
+  }, [enabled, openMenu])
+}
 
+function useMobileSelectionMenu({ enabled, openMenu, closeMenu, menuStateRef }) {
   useEffect(() => {
     if (!enabled) return
     const isTouch = matchMedia('(pointer: coarse)').matches
@@ -52,82 +101,92 @@ export function useOverlayContextMenu(enabled = true) {
 
     let touchActive = false
 
-    function openMenuFromSelection() {
-      const sel = window.getSelection()
-      const text = sel?.toString().trim() ?? ''
-      console.log('[ctxmenu] openMenuFromSelection — collapsed:', sel?.isCollapsed, '| text:', text.slice(0, 40))
-      if (!sel || sel.isCollapsed || !text) return
-
-      if (!sel.anchorNode?.parentElement?.closest('[data-overlay-content]')) {
-        console.log('[ctxmenu] openMenuFromSelection — selection not inside [data-overlay-content], skipping')
-        return
+    function readOverlaySelection() {
+      const selection = window.getSelection()
+      const selectedText = selection?.toString().trim() ?? ''
+      if (!selection || selection.isCollapsed || !selectedText) return null
+      if (!selection.anchorNode?.parentElement?.closest('[data-overlay-content]')) {
+        console.log('[ctxmenu] readOverlaySelection — selection not inside [data-overlay-content], skipping')
+        return null
       }
 
-      const rect = sel.getRangeAt(0).getBoundingClientRect()
-      openedBySelectionRef.current = true
-      setMenuState({
-        isOpen: true,
+      const rect = selection.getRangeAt(0).getBoundingClientRect()
+      return {
         anchorX: rect.left + rect.width / 2,
         anchorY: rect.bottom + 12,
-        selectedText: text,
+        selectedText,
+      }
+    }
+
+    function openFromSelection() {
+      const selectionMenu = readOverlaySelection()
+      if (!selectionMenu) return
+      openMenu({
+        source: MenuOpenSource.MOBILE_SELECTION,
+        ...selectionMenu,
       })
-      console.log('[ctxmenu] opened via selection at', rect.left + rect.width / 2, rect.bottom + 12, '| text:', text.slice(0, 40))
+      console.log('[ctxmenu] opened via selection at', selectionMenu.anchorX, selectionMenu.anchorY, '| text:', selectionMenu.selectedText.slice(0, 40))
     }
 
     function handleSelectionChange() {
-      const selection = window.getSelection()
-      const text = selection?.toString().trim() ?? ''
-      if (!selection || selection.isCollapsed || !text) {
+      const selectionMenu = readOverlaySelection()
+      const openedFromMobileSelection =
+        menuStateRef.current.source === MenuOpenSource.MOBILE_SELECTION
+
+      if (!selectionMenu) {
         // Guard: don't close the menu mid-touch. On mobile a tap on the menu
         // button collapses the selection (touchstart) before click fires —
         // closing here would ghost-click whatever is underneath the menu.
-        if (openedBySelectionRef.current && !touchActive) {
+        if (openedFromMobileSelection && !touchActive) {
           console.log('[ctxmenu] selectionchange — cleared (not touching), closing menu')
           closeMenu()
-        } else if (openedBySelectionRef.current) {
+        } else if (openedFromMobileSelection) {
           console.log('[ctxmenu] selectionchange — cleared but touchActive, keeping menu open to avoid ghost click')
         }
         return
       }
-      console.log('[ctxmenu] selectionchange — touchActive:', touchActive, '| text:', text.slice(0, 40))
-      if (!touchActive) openMenuFromSelection()
+
+      console.log('[ctxmenu] selectionchange — touchActive:', touchActive, '| text:', selectionMenu.selectedText.slice(0, 40))
+      if (!touchActive) openFromSelection()
     }
 
     function handleTouchStart() {
       touchActive = true
       console.log('[ctxmenu] touchstart')
     }
+
     function handleTouchEnd() {
       touchActive = false
-      console.log('[ctxmenu] touchend — will attempt openMenuFromSelection')
-      openMenuFromSelection()
+      console.log('[ctxmenu] touchend — will attempt openFromSelection')
+      openFromSelection()
     }
 
     document.addEventListener('selectionchange', handleSelectionChange)
     document.addEventListener('touchstart', handleTouchStart, true)
     document.addEventListener('touchend', handleTouchEnd, true)
+
     return () => {
       document.removeEventListener('selectionchange', handleSelectionChange)
       document.removeEventListener('touchstart', handleTouchStart, true)
       document.removeEventListener('touchend', handleTouchEnd, true)
     }
-  }, [enabled, closeMenu])
+  }, [enabled, openMenu, closeMenu, menuStateRef])
+}
 
+function useOverlayMenuDismissal({ isOpen, menuRef, closeMenu, menuStateRef }) {
   useEffect(() => {
-    if (enabled) return
-    closeMenu()
-  }, [closeMenu, enabled])
-
-  useEffect(() => {
-    if (!menuState.isOpen) return
+    if (!isOpen) return
     console.log('[ctxmenu] attaching close listeners (menu open)')
 
     function handlePointerDown(event) {
       const isInsideMenu = menuRef.current?.contains(event.target)
       console.log('[ctxmenu] pointerdown — insideMenu:', isInsideMenu)
       if (isInsideMenu) return
-      if (openedBySelectionRef.current) window.getSelection()?.removeAllRanges()
-      closeMenu()
+
+      closeMenu({
+        clearSelection:
+          menuStateRef.current.source === MenuOpenSource.MOBILE_SELECTION,
+      })
     }
 
     function handleKeyDown(event) {
@@ -147,12 +206,5 @@ export function useOverlayContextMenu(enabled = true) {
       document.removeEventListener('pointerdown', handlePointerDown, true)
       document.removeEventListener('keydown', handleKeyDown, true)
     }
-  }, [closeMenu, menuState.isOpen])
-
-  return {
-    ...menuState,
-    menuRef,
-    handleContextMenu,
-    closeMenu,
-  }
+  }, [closeMenu, isOpen, menuRef, menuStateRef])
 }

--- a/client/src/hooks/useOverlayContextMenu.js
+++ b/client/src/hooks/useOverlayContextMenu.js
@@ -4,6 +4,7 @@ const CLOSED_MENU_STATE = Object.freeze({
   isOpen: false,
   anchorX: 0,
   anchorY: 0,
+  selectedText: '',
 })
 
 // CONTRACT — this hook pairs with two things that must cooperate:
@@ -68,17 +69,23 @@ export function useOverlayContextMenu(enabled = true) {
         isOpen: true,
         anchorX: rect.left + rect.width / 2,
         anchorY: rect.bottom + 12,
+        selectedText: text,
       })
-      console.log('[ctxmenu] opened via selection at', rect.left + rect.width / 2, rect.bottom + 12)
+      console.log('[ctxmenu] opened via selection at', rect.left + rect.width / 2, rect.bottom + 12, '| text:', text.slice(0, 40))
     }
 
     function handleSelectionChange() {
       const selection = window.getSelection()
       const text = selection?.toString().trim() ?? ''
       if (!selection || selection.isCollapsed || !text) {
-        if (openedBySelectionRef.current) {
-          console.log('[ctxmenu] selectionchange — cleared, closing menu')
+        // Guard: don't close the menu mid-touch. On mobile a tap on the menu
+        // button collapses the selection (touchstart) before click fires —
+        // closing here would ghost-click whatever is underneath the menu.
+        if (openedBySelectionRef.current && !touchActive) {
+          console.log('[ctxmenu] selectionchange — cleared (not touching), closing menu')
           closeMenu()
+        } else if (openedBySelectionRef.current) {
+          console.log('[ctxmenu] selectionchange — cleared but touchActive, keeping menu open to avoid ghost click')
         }
         return
       }

--- a/serve.py
+++ b/serve.py
@@ -17,7 +17,7 @@ import tldr_app
 import storage_service
 import shopping_cart_service
 from hidden_apps.portfolio.routes import portfolio_bp
-from summarizer import DEFAULT_MODEL, DEFAULT_SUMMARY_EFFORT
+from summarizer import DEFAULT_MODEL, DEFAULT_THINKING_EFFORT, DEFAULT_ELABORATE_MODEL
 from source_routes import source_bp
 
 # Configure Flask to serve React build output
@@ -125,7 +125,7 @@ def summarize_url_endpoint(model: str = DEFAULT_MODEL):
         model_param = request.args.get("model", DEFAULT_MODEL)
         result = tldr_app.summarize_url(
             data.get("url", ""),
-            summarize_effort=data.get("summarize_effort", DEFAULT_SUMMARY_EFFORT),
+            summarize_effort=data.get("summarize_effort", DEFAULT_THINKING_EFFORT),
             model=model_param,
         )
 
@@ -151,14 +151,14 @@ def summarize_url_endpoint(model: str = DEFAULT_MODEL):
 
 
 @app.route("/api/elaborate", methods=["POST"])
-def elaborate_endpoint(model: str = DEFAULT_MODEL):
+def elaborate_endpoint(model: str = DEFAULT_ELABORATE_MODEL):
     """Elaborate on a selected portion of a previously-generated summary.
 
     Requires 'url', 'selected_text', and 'summary_markdown' in the JSON body. Optional 'model' query param.
     """
     try:
         data = request.get_json()
-        model_param = request.args.get("model", DEFAULT_MODEL)
+        model_param = request.args.get("model", DEFAULT_ELABORATE_MODEL)
         result = tldr_app.elaborate_url(
             data["url"],
             data["selected_text"],

--- a/serve.py
+++ b/serve.py
@@ -150,6 +150,41 @@ def summarize_url_endpoint(model: str = DEFAULT_MODEL):
         return jsonify({"success": False, "error": repr(e)}), 500
 
 
+@app.route("/api/elaborate", methods=["POST"])
+def elaborate_endpoint(model: str = DEFAULT_MODEL):
+    """Elaborate on a selected portion of a previously-generated summary.
+
+    Requires 'url', 'selected_text', and 'summary_markdown' in the JSON body. Optional 'model' query param.
+    """
+    try:
+        data = request.get_json()
+        model_param = request.args.get("model", DEFAULT_MODEL)
+        result = tldr_app.elaborate_url(
+            data["url"],
+            data["selected_text"],
+            data["summary_markdown"],
+            model=model_param,
+        )
+        return jsonify(result)
+
+    except ValueError as error:
+        return jsonify({"success": False, "error": str(error)}), 400
+    except requests.RequestException as error:
+        logger.error(
+            "request error error=%s",
+            repr(error),
+            exc_info=True,
+        )
+        return jsonify({"success": False, "error": f"Network error: {repr(error)}"}), 502
+    except Exception as error:
+        logger.error(
+            "error error=%s",
+            repr(error),
+            exc_info=True,
+        )
+        return jsonify({"success": False, "error": repr(error)}), 500
+
+
 @app.route("/api/digest", methods=["POST"])
 def digest_endpoint():
     """Generate a synthesized digest from multiple article URLs.

--- a/sessions.yaml
+++ b/sessions.yaml
@@ -1,0 +1,48 @@
+# sessions.yaml Schema:
+# ```yaml
+# sessions: <SessionID: SessionEntry>
+# ignored: <SessionID[]>   # A list of zero or more session ids to not include in the `sessions` object.
+# ```
+
+# SessionEntry Schema:
+# ```yaml
+#   description (str OR str[]): A 1–2 phrase summary of the purpose of the session (why did it take place) and progress (what was done). Include no implementation details. If the session is exceptionally long, this field may be a list, allowing the session to be split into “chapters,” with each chapter given its own description string.
+#   custom_title (optional str): if explicitly provided in the input.
+#   directories (str[]): a list of the session’s directory and any root directories of other repos if such repos where actively researched or modified.
+#   updated_when_message_count_was (int): the number of messages in the session when it was last updated. This data should be available from the conversation’s metadata.
+#   keywords (optional str[]): 1–3 session-specific, domain-specific keywords that capture the domain/business and entities as well as the session’s essence(s)—brainstorming, planning, implementation, research, or anything else of this nature, or any combination thereof. Think: “If someone wanted to find past sessions for domain context, or to recall a useful technique or piece of information on a specific topic, what keywords would help them discover this session?” Keywords should be MECE.
+#   prominent_tech_stack (optional str[]): important tech stack used or discussed, if it all. usually between 0 and 2 items. this field should heavily optimize for precision disregarding recall (e.g. high session-relevancy threshold for including any item)
+#   new_files (optional str[]): list of new files created in the session.
+#   edited_files (optional str[]): list of files edited in the session.
+#   branch (optional str): the branch of the session, if applicable.
+#   jira_issue_id (optional str): the JIRA issue ID of the session, if applicable.
+#   forked (optional str): the session ID the attached session was forked from, only if explicitly referenced in the beginning of the text.
+# ```
+
+# Ignored Sessions List. Schema:
+# ```yaml
+# ignored: <SessionID[]>
+# ```
+
+# -------
+# Example sessions.yaml file:
+sessions:
+  # Apr 20 2026
+  8d2faf95-fdde-48d4-89eb-67fe0c1c683b:
+    description:
+      - "Debugged broken 'Elaborate on selected text' context menu: mobile selection collapsed before click fired (fixed by capturing selectedText at menu-open time), and a touchActive guard was missing causing ghost-clicks to close the menu."
+      - "Found the actual root cause — React portal event bubbling through the React component tree (not DOM) caused clicks on the context menu to reach ArticleCard's onClick and collapse the overlay; fixed with e.stopPropagation() on portal containers. Documented in GOTCHAS."
+    custom_title: "elaborate context menu client impl"
+    directories: [~/dev/TLDRScraper]
+    keywords: [elaborate, context-menu, react-portal-event-bubbling, mobile-selection]
+    prominent_tech_stack: [React]
+    updated_when_message_count_was: 32
+    edited_files:
+      - client/src/components/ElaborationPreview.jsx
+      - client/src/components/OverlayContextMenu.jsx
+      - client/src/components/ZenModeOverlay.jsx
+      - client/src/hooks/useOverlayContextMenu.js
+      - GOTCHAS.md
+    branch: claude/add-elaborate-context-menu-jRtLS
+
+ignored: [dda16bd3-68fa-4cc9-86b5-fb6e6a532b41]

--- a/summarizer.py
+++ b/summarizer.py
@@ -306,6 +306,40 @@ def summarize_url(url: str, summarize_effort: str = DEFAULT_SUMMARY_EFFORT, mode
     return summary
 
 
+def _build_elaborate_prompt(selected_text: str, summary_markdown: str, article_markdown: str) -> str:
+    """Construct the Elaborate prompt instructing the LLM to expand on a selected slice of the summary.
+
+    >>> prompt = _build_elaborate_prompt("sel", "sum", "body")
+    >>> '<selected-text-to-elaborate-on>' in prompt and '<summary>' in prompt and '<original-article>' in prompt
+    True
+    >>> prompt.index('<selected-text-to-elaborate-on>') < prompt.index('<summary>') < prompt.index('<original-article>')
+    True
+    """
+    return (
+        "The user has read the given summary and has requested to understand the following part better "
+        "In the original article. Because in that particular part, the summary was too lossy.\n\n"
+        f"<selected-text-to-elaborate-on>\n{selected_text}\n</selected-text-to-elaborate-on>\n\n"
+        f"<summary>\n{summary_markdown}\n</summary>\n\n"
+        f"<original-article>\n{article_markdown}\n</original-article>\n\n"
+        "You can think as long as you deem necessary but make sure your user-facing tokens are just the elaboration. "
+        "The elaboration should be without pleasantries, introductions, and so on. "
+        "Richly use Markdown syntax to improve the reading experience."
+    )
+
+
+def elaborate_url(
+    url: str,
+    selected_text: str,
+    summary_markdown: str,
+    *,
+    model: str = DEFAULT_MODEL,
+) -> str:
+    """Scrape the article at `url` and ask the LLM to elaborate on `selected_text` using the prior summary as context."""
+    article_markdown = url_to_markdown(url)
+    prompt = _build_elaborate_prompt(selected_text, summary_markdown, article_markdown)
+    return _call_llm(prompt, summarize_effort="high", model=model)
+
+
 def _fetch_prompt(
     *,
     owner: str,

--- a/summarizer.py
+++ b/summarizer.py
@@ -26,20 +26,21 @@ _SUMMARY_PROMPT_CACHE = None
 _DIGEST_PROMPT_CACHE = None
 
 SUMMARIZE_EFFORT_OPTIONS = ("minimal", "low", "medium", "high")
-DEFAULT_SUMMARY_EFFORT = "low"
+DEFAULT_THINKING_EFFORT = "low"
 DEFAULT_MODEL = "gemini-3.1-pro-preview"
+DEFAULT_ELABORATE_MODEL="gemini-3-flash-preview"
 
 
 def normalize_summarize_effort(value: str) -> str:
     """Normalize summary effort value to a supported option."""
     if not isinstance(value, str):
-        return DEFAULT_SUMMARY_EFFORT
+        return DEFAULT_THINKING_EFFORT
 
     normalized = value.strip().lower()
     if normalized in SUMMARIZE_EFFORT_OPTIONS:
         return normalized
 
-    return DEFAULT_SUMMARY_EFFORT
+    return DEFAULT_THINKING_EFFORT
 
 
 def _is_github_repo_url(url: str) -> bool:
@@ -285,7 +286,7 @@ def url_to_markdown(url: str) -> str:
     return markdown
 
 
-def summarize_url(url: str, summarize_effort: str = DEFAULT_SUMMARY_EFFORT, model: str = DEFAULT_MODEL) -> str:
+def summarize_url(url: str, summarize_effort: str = DEFAULT_THINKING_EFFORT, model: str = DEFAULT_MODEL) -> str:
     """Get markdown content from URL and create a summary with LLM.
 
     Args:
@@ -301,7 +302,7 @@ def summarize_url(url: str, summarize_effort: str = DEFAULT_SUMMARY_EFFORT, mode
 
     template = _fetch_summary_prompt()
     prompt = f"{template}\n\n<tldr this>\n{markdown}/n</tldr this>"
-    summary = _call_llm(prompt, summarize_effort=effort, model=model)
+    summary = _call_llm(prompt, thinking_effort=effort, model=model)
 
     return summary
 
@@ -316,13 +317,15 @@ def _build_elaborate_prompt(selected_text: str, summary_markdown: str, article_m
     True
     """
     return (
-        "The user has read the given summary and has requested to understand the following part better "
-        "In the original article. Because in that particular part, the summary was too lossy.\n\n"
+        "The user has read the given summary and has request to understand the selected text better.\n"
+        "Draw from the original article to provide more depth, in a way which meshes organically with that part’s role in the article.\n\n"
+        "Don’t be lengthy in your response. Not verbose. Direct, succinct, concise, focused, rich, and just enough content to get the information across.\n\n"
         f"<selected-text-to-elaborate-on>\n{selected_text}\n</selected-text-to-elaborate-on>\n\n"
         f"<summary>\n{summary_markdown}\n</summary>\n\n"
         f"<original-article>\n{article_markdown}\n</original-article>\n\n"
+        "---\n\n"
         "You can think as long as you deem necessary but make sure your user-facing tokens are just the elaboration. "
-        "The elaboration should be without pleasantries, introductions, and so on. "
+        "No pleasantries, introductions, and so on. "
         "Richly use Markdown syntax to improve the reading experience."
     )
 
@@ -332,12 +335,12 @@ def elaborate_url(
     selected_text: str,
     summary_markdown: str,
     *,
-    model: str = DEFAULT_MODEL,
+    model: str,
 ) -> str:
     """Scrape the article at `url` and ask the LLM to elaborate on `selected_text` using the prior summary as context."""
     article_markdown = url_to_markdown(url)
     prompt = _build_elaborate_prompt(selected_text, summary_markdown, article_markdown)
-    return _call_llm(prompt, summarize_effort="high", model=model)
+    return _call_llm(prompt, thinking_effort="high", model=model)
 
 
 def _fetch_prompt(
@@ -490,7 +493,7 @@ def _map_reasoning_effort_to_thinking_level(summarize_effort: str) -> str:
     return "high"
 
 
-def _call_llm(prompt: str, summarize_effort: str = DEFAULT_SUMMARY_EFFORT, model: str = DEFAULT_MODEL) -> str:
+def _call_llm(prompt: str, thinking_effort: str = DEFAULT_THINKING_EFFORT, model: str = DEFAULT_MODEL) -> str:
     """Call Gemini API with prompt."""
     api_key = util.resolve_env_var("GEMINI_API_KEY", "")
     if not api_key:
@@ -498,7 +501,7 @@ def _call_llm(prompt: str, summarize_effort: str = DEFAULT_SUMMARY_EFFORT, model
     if not prompt.strip():
         raise ValueError("Prompt is empty")
 
-    thinking_level = _map_reasoning_effort_to_thinking_level(summarize_effort)
+    thinking_level = _map_reasoning_effort_to_thinking_level(thinking_effort)
 
     url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
     headers = {

--- a/thoughts/26-04-07-context-menu-research/plans/1-split-mobile-and-desktop.plan.md
+++ b/thoughts/26-04-07-context-menu-research/plans/1-split-mobile-and-desktop.plan.md
@@ -1,0 +1,459 @@
+---
+last_updated: 2026-04-24 06:28
+originates_from: impl-review/review-1.md
+status: implemented
+---
+
+# Split Desktop and Mobile Overlay Menu Paths Implementation Plan
+
+## Overview
+
+Implement the first item from `impl-review/review-1.md`: split the desktop right-click path and the mobile text-selection path inside the overlay context menu. The goal is a behavior-preserving refactor that reduces timing/race complexity while keeping the public `useOverlayContextMenu` API stable for `ZenModeOverlay`.
+
+This is intentionally a small first move. It should make later work easier, especially the mobile reducer and eventual Floating UI/BaseUI migration, without changing the visible product behavior in this pass.
+
+## Current State Analysis
+
+`client/src/hooks/useOverlayContextMenu.js` currently owns every path in one hook:
+
+- Desktop right-click opens the menu from `handleContextMenu` at `useOverlayContextMenu.js:33`.
+- Mobile selection is handled by document-level `selectionchange`, `touchstart`, and `touchend` listeners at `useOverlayContextMenu.js:47`.
+- Close behavior for outside pointerdown and Escape is shared in a separate effect at `useOverlayContextMenu.js:121`.
+- `openedBySelectionRef` at `useOverlayContextMenu.js:23` is the discriminator for whether closing should clear the browser selection.
+
+The hook is consumed only by `ZenModeOverlay` today:
+
+- `ZenModeOverlay.jsx:16` calls `useOverlayContextMenu(true)`.
+- `ZenModeOverlay.jsx:133` threads `contextMenu.handleContextMenu` into `BaseOverlay`.
+- `ZenModeOverlay.jsx:138` renders `OverlayContextMenu` with `contextMenu.isOpen`, anchor coordinates, `menuRef`, and `selectedText`.
+
+The shared overlay contract still lives in `BaseOverlay`:
+
+- `BaseOverlay.jsx:18` accepts `onContentContextMenu`.
+- `BaseOverlay.jsx:52` respects `event.defaultPrevented` so Escape closes the menu before it closes the overlay.
+- `BaseOverlay.jsx:114` attaches the context-menu handler to the scroll surface.
+- `BaseOverlay.jsx:115` marks the selection scope with `data-overlay-content`.
+
+`OverlayContextMenu` already depends on a captured `selectedText` when mobile selection collapses before click:
+
+- `OverlayContextMenu.jsx:39` prefers the selected text captured at menu-open time.
+- `OverlayContextMenu.jsx:41` clears the live browser selection when an action is clicked.
+
+`DigestOverlay` composes `BaseOverlay` but does not compose the context menu. This plan must not accidentally wire Digest or change its behavior.
+
+## Desired End State
+
+`useOverlayContextMenu` remains the single exported hook and still returns the same UI-facing shape:
+
+```js
+{
+  isOpen,
+  anchorX,
+  anchorY,
+  selectedText,
+  menuRef,
+  handleContextMenu,
+  closeMenu,
+}
+```
+
+Internally, it delegates to three small owners:
+
+1. `useDesktopContextMenu`: desktop right-click only.
+2. `useMobileSelectionMenu`: mobile native text-selection only.
+3. `useOverlayMenuDismissal`: close-on-outside and Escape only.
+
+The visible behavior after implementation should be unchanged:
+
+- Right-click in Zen prose opens the menu at the cursor.
+- Mobile text selection in Zen prose opens the menu near the selection.
+- Tapping Elaborate still receives the selected text.
+- Outside pointerdown closes the menu.
+- First Escape closes the menu only; second Escape closes the overlay.
+- Digest overlay remains without a context menu.
+
+## What We Are Not Doing
+
+- No Floating UI or BaseUI migration.
+- No reducer for mobile selection yet. That is the second recommended item.
+- No Digest overlay context-menu wiring.
+- No backend elaboration changes.
+- No `BaseOverlay` contract relocation.
+- No visual redesign of `OverlayContextMenu` or `ElaborationPreview`.
+- No pull-to-close restoration. It stays disabled in `BaseOverlay` for native text selection.
+- No broad debug-log cleanup unless a specific log line blocks verification.
+
+## Implementation Approach
+
+Keep the split inside `client/src/hooks/useOverlayContextMenu.js` for this first step. That gives the desired architectural separation without adding export churn or new folder structure. If the file becomes uncomfortable after the reducer step, move the private hooks into separate modules then.
+
+Use an explicit menu open source in state, replacing `openedBySelectionRef` as the conceptual discriminator:
+
+```js
+const MenuOpenSource = Object.freeze({
+  NONE: 'none',
+  DESKTOP: 'desktop',
+  MOBILE_SELECTION: 'mobile-selection',
+})
+
+const CLOSED_MENU_STATE = Object.freeze({
+  isOpen: false,
+  anchorX: 0,
+  anchorY: 0,
+  selectedText: '',
+  source: MenuOpenSource.NONE,
+})
+```
+
+Do not expose `source` from the public hook return. It is internal coordination state for close semantics.
+
+Because document listeners need current state without constantly reattaching, mirror the current menu state into a ref:
+
+```js
+const menuStateRef = useRef(CLOSED_MENU_STATE)
+useEffect(() => {
+  menuStateRef.current = menuState
+}, [menuState])
+```
+
+Then shared listeners can read `menuStateRef.current.source` instead of carrying a separate `openedBySelectionRef`.
+
+## Phase 1: Split The Hook Internals
+
+### 1. Add Internal Source-Aware Commands
+
+**File**: `client/src/hooks/useOverlayContextMenu.js`
+
+Replace the current direct `setMenuState(...)` calls and `openedBySelectionRef` writes with two internal commands:
+
+```js
+const openMenu = useCallback(({ source, anchorX, anchorY, selectedText = '' }) => {
+  setMenuState({
+    isOpen: true,
+    anchorX,
+    anchorY,
+    selectedText,
+    source,
+  })
+}, [])
+
+const closeMenu = useCallback(({ clearSelection = false } = {}) => {
+  if (clearSelection) window.getSelection()?.removeAllRanges()
+  setMenuState(CLOSED_MENU_STATE)
+}, [])
+```
+
+Notes:
+
+- `closeMenu()` must keep working with no arguments because `ZenModeOverlay` passes it directly to `OverlayContextMenu`.
+- `OverlayContextMenu` can keep clearing selection before it calls `onClose()`. This plan does not require changing action-click behavior.
+- The source-aware close path is mainly for outside pointerdown, Escape, and mobile selection collapse.
+
+### 2. Extract Desktop Right-Click Ownership
+
+**File**: `client/src/hooks/useOverlayContextMenu.js`
+
+Add a private hook in the same file:
+
+```js
+function useDesktopContextMenu({ enabled, openMenu }) {
+  return useCallback((event) => {
+    if (!enabled) return
+
+    event.preventDefault()
+    openMenu({
+      source: MenuOpenSource.DESKTOP,
+      anchorX: event.clientX,
+      anchorY: event.clientY,
+      selectedText: '',
+    })
+  }, [enabled, openMenu])
+}
+```
+
+This hook should own only the `onContextMenu` path. It must not know about `selectionchange`, `touchstart`, `touchend`, Escape, outside pointerdown, or selection clearing.
+
+Behavior to preserve:
+
+- Desktop right-click should not call `window.getSelection().removeAllRanges()`.
+- If the user right-clicks while text is selected, `OverlayContextMenu` can still fall back to the live selection at action click time.
+- Non-enabled state is a no-op.
+
+### 3. Extract Mobile Text Selection Ownership
+
+**File**: `client/src/hooks/useOverlayContextMenu.js`
+
+Add a private hook in the same file:
+
+```js
+function useMobileSelectionMenu({ enabled, openMenu, closeMenu, menuStateRef }) {
+  useEffect(() => {
+    if (!enabled) return
+    if (!matchMedia('(pointer: coarse)').matches) return
+
+    let touchActive = false
+
+    function readOverlaySelection() {
+      const selection = window.getSelection()
+      const selectedText = selection?.toString().trim() ?? ''
+      if (!selection || selection.isCollapsed || !selectedText) return null
+      if (!selection.anchorNode?.parentElement?.closest('[data-overlay-content]')) return null
+
+      const rect = selection.getRangeAt(0).getBoundingClientRect()
+      return {
+        anchorX: rect.left + rect.width / 2,
+        anchorY: rect.bottom + 12,
+        selectedText,
+      }
+    }
+
+    function openFromSelection() {
+      const selectionMenu = readOverlaySelection()
+      if (!selectionMenu) return
+      openMenu({
+        source: MenuOpenSource.MOBILE_SELECTION,
+        ...selectionMenu,
+      })
+    }
+
+    function handleSelectionChange() {
+      const selectionMenu = readOverlaySelection()
+      const openedFromMobileSelection =
+        menuStateRef.current.source === MenuOpenSource.MOBILE_SELECTION
+
+      if (!selectionMenu) {
+        if (openedFromMobileSelection && !touchActive) closeMenu()
+        return
+      }
+
+      if (!touchActive) openFromSelection()
+    }
+
+    function handleTouchStart() {
+      touchActive = true
+    }
+
+    function handleTouchEnd() {
+      touchActive = false
+      openFromSelection()
+    }
+
+    document.addEventListener('selectionchange', handleSelectionChange)
+    document.addEventListener('touchstart', handleTouchStart, true)
+    document.addEventListener('touchend', handleTouchEnd, true)
+
+    return () => {
+      document.removeEventListener('selectionchange', handleSelectionChange)
+      document.removeEventListener('touchstart', handleTouchStart, true)
+      document.removeEventListener('touchend', handleTouchEnd, true)
+    }
+  }, [enabled, openMenu, closeMenu, menuStateRef])
+}
+```
+
+Keep the same DOM contract:
+
+- The mobile path must still ignore selections outside `[data-overlay-content]`.
+- The menu should still open on finger lift (`touchend`) rather than mid-gesture.
+- Clearing selection during a touch should not close the menu early, preserving the current ghost-click guard.
+
+Avoid widening the scope:
+
+- Do not add new mobile states like `idle`, `touching`, `selected`, or `closing` yet.
+- Do not introduce a reducer in this pass.
+- Do not change the positioning math yet.
+
+### 4. Extract Shared Dismissal Ownership
+
+**File**: `client/src/hooks/useOverlayContextMenu.js`
+
+Move the current open-menu close effect into a private hook:
+
+```js
+function useOverlayMenuDismissal({ isOpen, menuRef, closeMenu, menuStateRef }) {
+  useEffect(() => {
+    if (!isOpen) return
+
+    function handlePointerDown(event) {
+      if (menuRef.current?.contains(event.target)) return
+
+      closeMenu({
+        clearSelection:
+          menuStateRef.current.source === MenuOpenSource.MOBILE_SELECTION,
+      })
+    }
+
+    function handleKeyDown(event) {
+      if (event.key !== 'Escape') return
+
+      event.preventDefault()
+      event.stopPropagation()
+      event.stopImmediatePropagation()
+      closeMenu()
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown, true)
+    document.addEventListener('keydown', handleKeyDown, true)
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown, true)
+      document.removeEventListener('keydown', handleKeyDown, true)
+    }
+  }, [isOpen, menuRef, closeMenu, menuStateRef])
+}
+```
+
+Behavior to preserve:
+
+- Pointerdown inside the menu does nothing.
+- Pointerdown outside the menu clears live selection only for mobile-selection-opened menus.
+- Escape always closes the menu first and still prevents `BaseOverlay` from closing on that same keypress.
+
+### 5. Recompose The Public Hook
+
+**File**: `client/src/hooks/useOverlayContextMenu.js`
+
+The exported hook should become the coordinator:
+
+```js
+export function useOverlayContextMenu(enabled = true) {
+  const [menuState, setMenuState] = useState(CLOSED_MENU_STATE)
+  const menuRef = useRef(null)
+  const menuStateRef = useRef(menuState)
+
+  useEffect(() => {
+    menuStateRef.current = menuState
+  }, [menuState])
+
+  const openMenu = useCallback(...)
+  const closeMenu = useCallback(...)
+
+  const handleContextMenu = useDesktopContextMenu({ enabled, openMenu })
+  useMobileSelectionMenu({ enabled, openMenu, closeMenu, menuStateRef })
+  useOverlayMenuDismissal({
+    isOpen: menuState.isOpen,
+    menuRef,
+    closeMenu,
+    menuStateRef,
+  })
+
+  useEffect(() => {
+    if (enabled) return
+    closeMenu()
+  }, [closeMenu, enabled])
+
+  return {
+    isOpen: menuState.isOpen,
+    anchorX: menuState.anchorX,
+    anchorY: menuState.anchorY,
+    selectedText: menuState.selectedText,
+    menuRef,
+    handleContextMenu,
+    closeMenu,
+  }
+}
+```
+
+The exported hook must still be called exactly the same way from `ZenModeOverlay`. No `ZenModeOverlay` code changes should be necessary unless the refactor exposes a stale callback issue.
+
+### 6. Keep Consumers Stable
+
+**Files**:
+
+- `client/src/components/ZenModeOverlay.jsx`
+- `client/src/components/OverlayContextMenu.jsx`
+- `client/src/components/BaseOverlay.jsx`
+- `client/src/components/DigestOverlay.jsx`
+
+Expected changes:
+
+- `ZenModeOverlay.jsx`: none.
+- `OverlayContextMenu.jsx`: none, unless a type/shape mismatch requires using `selectedText ?? ''`.
+- `BaseOverlay.jsx`: none.
+- `DigestOverlay.jsx`: none.
+
+If any of these files need behavioral edits, treat that as a sign the refactor is leaking. Stop and re-check the hook API before widening the diff.
+
+### 7. Update Documentation After Verification
+
+**Files**:
+
+- `client/ARCHITECTURE.md`
+- `client/STATE_MACHINES.md`
+- `thoughts/26-04-07-context-menu-research/implementation/iteration-3.md` or equivalent implementation note, if continuing the existing research log pattern.
+
+Documentation should say:
+
+- The exported overlay context-menu primitive is still `useOverlayContextMenu`.
+- Internally, desktop right-click and mobile selection are separate paths.
+- The `BaseOverlay` contracts remain unchanged for now.
+- Digest remains a planned consumer, not an implemented consumer.
+
+Do not manually edit YAML frontmatter timestamps.
+
+## Acceptance Criteria
+
+### Automated Verification
+
+- [ ] `cd client && npm run build`
+- [ ] `cd client && CI=1 npm run lint`
+- [ ] Search sanity: `rg -n "openedBySelectionRef|touchActive" client/src/hooks/useOverlayContextMenu.js`
+  - `openedBySelectionRef` should be gone.
+  - `touchActive` should only exist inside `useMobileSelectionMenu`.
+- [ ] Search sanity: `rg -n "useOverlayContextMenu\\(" client/src`
+  - The only current call site should remain `ZenModeOverlay`.
+
+Only fix lint/build failures introduced by this refactor.
+
+### Manual Verification
+
+Desktop:
+
+1. Open a Zen summary overlay.
+2. Right-click in the prose body.
+3. Confirm the custom menu opens at the cursor and the native browser context menu does not.
+4. Press Escape once.
+5. Confirm only the menu closes.
+6. Press Escape again.
+7. Confirm the overlay closes.
+8. Reopen the overlay, select text with the mouse, right-click, choose Elaborate, and confirm the selected text reaches the preview.
+
+Mobile or mobile emulation:
+
+1. Open a Zen summary overlay.
+2. Long-press still on text until native selection appears.
+3. Confirm the custom menu opens near the selected text after finger lift.
+4. Tap Elaborate.
+5. Confirm the selection text is preserved and the elaboration preview opens.
+6. Reopen and select text, then drag selection handles to extend the selection.
+7. Confirm the menu remains tied to the selected text and does not close during the handle drag.
+8. Tap outside the menu.
+9. Confirm the menu closes and the native selection clears.
+
+Regression checks:
+
+1. Tap a normal article card with no text selected and confirm the summary open behavior still works.
+2. Tap inside selected overlay prose and confirm the underlying `ArticleCard` does not receive a ghost click.
+3. Use the bottom overscroll-up gesture and confirm mark-removed behavior is unchanged.
+4. Open a digest overlay and confirm it still has no context menu behavior.
+5. Confirm `ElaborationPreview` Escape/backdrop close still affects only the preview layer.
+
+## Risk Notes
+
+- Mobile selection is browser-owned state. The refactor should preserve the existing timing behavior before trying to improve it.
+- `menuStateRef` is an implementation detail for document listeners. The canonical source should remain React state, not a pile of independent refs.
+- Do not move the `data-overlay-content` contract yet. The third recommended review item owns that.
+- Do not change `OverlayContextMenu` positioning yet. Floating UI is the fourth recommended item.
+- Keep the diff boring. The purpose of this step is to untangle, not to add capability.
+
+## References
+
+- `thoughts/26-04-07-context-menu-research/impl-review/review-1.md`
+- `thoughts/26-04-07-context-menu-research/implementation/iteration-1.md`
+- `thoughts/26-04-07-context-menu-research/implementation/iteration-2.md`
+- `client/src/hooks/useOverlayContextMenu.js`
+- `client/src/components/OverlayContextMenu.jsx`
+- `client/src/components/BaseOverlay.jsx`
+- `client/src/components/ZenModeOverlay.jsx`
+- `client/ARCHITECTURE.md`
+- `client/STATE_MACHINES.md`

--- a/tldr_app.py
+++ b/tldr_app.py
@@ -67,3 +67,25 @@ def summarize_url(
     return payload
 
 
+def elaborate_url(
+    url: str,
+    selected_text: str,
+    summary_markdown: str,
+    *,
+    model: str = DEFAULT_MODEL,
+) -> dict:
+    """Shape the elaboration response for the HTTP layer."""
+    result = tldr_service.elaborate_url_content(
+        url,
+        selected_text,
+        summary_markdown,
+        model=model,
+    )
+
+    return {
+        "success": True,
+        "elaboration_markdown": result["elaboration_markdown"],
+        "canonical_url": result["canonical_url"],
+    }
+
+

--- a/tldr_app.py
+++ b/tldr_app.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 
 import tldr_service
-from summarizer import DEFAULT_MODEL, DEFAULT_SUMMARY_EFFORT
+from summarizer import DEFAULT_MODEL, DEFAULT_THINKING_EFFORT
 
 logger = logging.getLogger("tldr_app")
 
@@ -42,7 +42,7 @@ def generate_digest(articles: list[dict], effort: str = "low") -> dict:
 def summarize_url(
     url: str,
     *,
-    summarize_effort: str = DEFAULT_SUMMARY_EFFORT,
+    summarize_effort: str = DEFAULT_THINKING_EFFORT,
     model: str = DEFAULT_MODEL,
 ) -> dict:
     result = tldr_service.summarize_url_content(
@@ -72,7 +72,7 @@ def elaborate_url(
     selected_text: str,
     summary_markdown: str,
     *,
-    model: str = DEFAULT_MODEL,
+    model: str,
 ) -> dict:
     """Shape the elaboration response for the HTTP layer."""
     result = tldr_service.elaborate_url_content(

--- a/tldr_service.py
+++ b/tldr_service.py
@@ -434,3 +434,42 @@ def summarize_url_content(
         "canonical_url": canonical_url,
         "summarize_effort": normalized_effort,
     }
+
+
+def elaborate_url_content(
+    url: str,
+    selected_text: str,
+    summary_markdown: str,
+    *,
+    model: str = DEFAULT_MODEL,
+) -> dict:
+    """Canonicalize `url`, scrape it, and ask the LLM to elaborate on `selected_text` given the prior `summary_markdown`."""
+    cleaned_url = (url or "").strip()
+    if not cleaned_url:
+        raise ValueError("Missing url")
+    if not (selected_text or "").strip():
+        raise ValueError("Missing selected_text")
+    if not (summary_markdown or "").strip():
+        raise ValueError("Missing summary_markdown")
+
+    canonical_url = util.canonicalize_url(cleaned_url)
+
+    try:
+        elaboration_markdown = summarizer.elaborate_url(
+            canonical_url,
+            selected_text,
+            summary_markdown,
+            model=model,
+        )
+    except requests.RequestException as error:
+        logger.error(
+            "request error error=%s",
+            repr(error),
+            exc_info=True,
+        )
+        raise
+
+    return {
+        "elaboration_markdown": elaboration_markdown,
+        "canonical_url": canonical_url,
+    }

--- a/tldr_service.py
+++ b/tldr_service.py
@@ -16,7 +16,7 @@ from newsletter_scraper import (
 import summarizer
 from summarizer import (
     DEFAULT_MODEL,
-    DEFAULT_SUMMARY_EFFORT,
+    DEFAULT_THINKING_EFFORT,
     _fetch_summary_prompt,
     normalize_summarize_effort,
     summarize_url,
@@ -384,7 +384,7 @@ def generate_digest(articles: list[dict], effort: str = "low") -> dict:
     template = summarizer._fetch_digest_prompt()
     prompt = summarizer._build_digest_prompt(template, successful)
 
-    digest_markdown = summarizer._call_llm(prompt, summarize_effort=normalized_effort)
+    digest_markdown = summarizer._call_llm(prompt, thinking_effort=normalized_effort)
 
     included_urls = [article["url"] for article in successful]
     storage_service.set_digest(digest_id, digest_markdown, included_urls, len(successful), normalized_effort)
@@ -405,7 +405,7 @@ def fetch_summary_prompt_template() -> str:
 def summarize_url_content(
     url: str,
     *,
-    summarize_effort: str = DEFAULT_SUMMARY_EFFORT,
+    summarize_effort: str = DEFAULT_THINKING_EFFORT,
     model: str = DEFAULT_MODEL,
 ) -> dict:
     cleaned_url = (url or "").strip()
@@ -441,7 +441,7 @@ def elaborate_url_content(
     selected_text: str,
     summary_markdown: str,
     *,
-    model: str = DEFAULT_MODEL,
+    model: str,
 ) -> dict:
     """Canonicalize `url`, scrape it, and ask the LLM to elaborate on `selected_text` given the prior `summary_markdown`."""
     cleaned_url = (url or "").strip()


### PR DESCRIPTION
Add a single "Elaborate" action to the per-article Zen reader that asks
the LLM to expand on a user-selected passage using the original scraped
article plus the prior summary as context. New POST /api/elaborate
endpoint accepts {url, selected_text, summary_markdown}, scrapes the
canonical URL, and calls Gemini with a prompt that emits only the
elaboration as user-facing tokens.

The context menu's action handler now captures the selected text before
clearing the selection and forwards it to each action's onSelect.

Digest overlay's placeholder menu is removed — it has no single
article-level URL/summary to elaborate on, and its placeholder actions
duplicated existing overlay chrome.