### PR TITLE
Use UTC day bounds for Hacker News scraping and add utc_day_epoch_seconds_bounds util

### DIFF
--- a/adapters/hackernews_adapter.py
+++ b/adapters/hackernews_adapter.py
@@ -1,7 +1,6 @@
 """Hacker News adapter that fetches Show HN stories for a specific date."""
 
 import logging
-from datetime import datetime
 
 from adapters.newsletter_adapter import NewsletterAdapter
 import util
@@ -22,13 +21,12 @@ class HackerNewsAdapter(NewsletterAdapter):
 
     def scrape_date(self, date: str, excluded_urls: list[str]) -> dict:
         """Fetch and normalize Show HN stories for a date."""
-        target_date = datetime.fromisoformat(util.format_date_for_url(date))
-        start_of_day = target_date.replace(hour=0, minute=0, second=0, microsecond=0)
-        end_of_day = target_date.replace(hour=23, minute=59, second=59, microsecond=0)
+        date_str = util.format_date_for_url(date)
+        start_timestamp, end_timestamp_exclusive = util.utc_day_epoch_seconds_bounds(date_str)
 
         stories = self._fetch_stories_algolia(
-            start_timestamp=int(start_of_day.timestamp()),
-            end_timestamp=int(end_of_day.timestamp()),
+            start_timestamp=start_timestamp,
+            end_timestamp=end_timestamp_exclusive,
             min_points=self.min_points,
             min_comments=self.min_comments,
             limit=self.max_stories,
@@ -43,7 +41,7 @@ class HackerNewsAdapter(NewsletterAdapter):
             canonical_url = util.canonicalize_url(url)
             if canonical_url in excluded_set:
                 continue
-            article = self._algolia_story_to_article(story, date)
+            article = self._algolia_story_to_article(story, date_str)
             if article:
                 articles.append(article)
 

--- a/util.py
+++ b/util.py
@@ -2,7 +2,7 @@ import functools
 import logging
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 import requests
@@ -74,6 +74,26 @@ def next_day_midnight_pacific_epoch_seconds(date_str: str) -> float:
     return next_day_midnight_pacific.timestamp()
 
 
+def utc_day_epoch_seconds_bounds(date_str: str) -> tuple[int, int]:
+    """Return [start, end) epoch seconds bounds for a UTC calendar day.
+
+    >>> utc_day_epoch_seconds_bounds("2025-01-23")
+    (1737590400, 1737676800)
+    """
+    target_date = datetime.fromisoformat(date_str)
+    start_of_day_utc = datetime(
+        target_date.year,
+        target_date.month,
+        target_date.day,
+        0,
+        0,
+        0,
+        tzinfo=timezone.utc,
+    )
+    end_of_day_utc_exclusive = start_of_day_utc + timedelta(days=1)
+    return int(start_of_day_utc.timestamp()), int(end_of_day_utc_exclusive.timestamp())
+
+
 def should_rescrape(date_str: str, cached_at_epoch_seconds: float | None) -> bool:
     """
     Determine if a date needs rescraping based on when it was last scraped.
@@ -84,7 +104,7 @@ def should_rescrape(date_str: str, cached_at_epoch_seconds: float | None) -> boo
     if cached_at_epoch_seconds is None:
         return True
 
-    next_day_midnight_epoch = next_day_midnight_pacific_epoch_seconds(date_str)
+    _, next_day_midnight_epoch = utc_day_epoch_seconds_bounds(date_str)
     return cached_at_epoch_seconds < next_day_midnight_epoch
 
 


### PR DESCRIPTION
### Motivation
- Ensure Hacker News Show HN queries use UTC calendar-day bounds to align with Algolia timestamps and avoid missing or duplicating stories across day boundaries. 
- Standardize the date value passed to story-to-article conversion to a formatted date string.

### Description
- Added `utc_day_epoch_seconds_bounds(date_str)` to `util.py` to return `[start, end)` epoch-second bounds for a UTC calendar day and imported `timezone` from `datetime`.
- Updated `should_rescrape` to use the end bound from `utc_day_epoch_seconds_bounds` as the rescrape cutoff instead of a Pacific-midnight calculation.
- Modified `HackerNewsAdapter.scrape_date` to call `util.utc_day_epoch_seconds_bounds`, pass `start_timestamp` and `end_timestamp_exclusive` to `_fetch_stories_algolia`, and forward the formatted `date_str` to `_algolia_story_to_article`.
- Removed an unused `datetime` import from `adapters/hackernews_adapter.py` and adjusted variable names to reflect the new UTC-exclusive end timestamp.

### Testing
- Ran the automated unit test suite with `pytest -q` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a4d14798833282c16d3747f2ddd5)