### PR TITLE
Refactor overlay menu/dialog to BaseUI primitives

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@base-ui-components/react": "^1.0.0-rc.0",
         "@floating-ui/react": "^0.27.19",
         "dompurify": "^3.3.0",
         "framer-motion": "^11.15.0",
@@ -279,6 +280,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -325,6 +335,62 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui-components/react": {
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@base-ui-components/react/-/react-1.0.0-rc.0.tgz",
+      "integrity": "sha512-9lhUFbJcbXvc9KulLev1WTFxS/alJRBWDH/ibKSQaNvmDwMFS2gKp1sTeeldYSfKuS/KC1w2MZutc0wHu2hRHQ==",
+      "deprecated": "Package was renamed to @base-ui/react",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "@base-ui-components/utils": "0.2.2",
+        "@floating-ui/react-dom": "^2.1.6",
+        "@floating-ui/utils": "^0.2.10",
+        "reselect": "^5.1.1",
+        "tabbable": "^6.3.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui-components/utils": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@base-ui-components/utils/-/utils-0.2.2.tgz",
+      "integrity": "sha512-rNJCD6TFy3OSRDKVHJDzLpxO3esTV1/drRtWNUpe7rCpPN9HZVHUCuP+6rdDYDGWfXnQHbqi05xOyRP2iZAlkw==",
+      "deprecated": "Package was renamed to @base-ui/utils",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "@floating-ui/utils": "^0.2.10",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {
@@ -1914,7 +1980,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2131,7 +2197,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3145,6 +3211,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -3376,6 +3448,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "lint": "./scripts/lint.sh"
   },
   "dependencies": {
+    "@base-ui-components/react": "^1.0.0-rc.0",
     "@floating-ui/react": "^0.27.19",
     "dompurify": "^3.3.0",
     "framer-motion": "^11.15.0",

--- a/client/src/components/ElaborationPreview.jsx
+++ b/client/src/components/ElaborationPreview.jsx
@@ -83,7 +83,6 @@ function ElaborationPreview({ isOpen, status, selectedText, markdown, errorMessa
               <Dialog.Backdrop className="absolute inset-0 bg-slate-900/30 backdrop-blur-sm" />
               <Dialog.Popup
                 initialFocus={closeButtonRef}
-                finalFocus={closeButtonRef}
                 render={<motion.div />}
                 role="dialog"
                 aria-modal={true}

--- a/client/src/components/ElaborationPreview.jsx
+++ b/client/src/components/ElaborationPreview.jsx
@@ -1,12 +1,4 @@
-import {
-  FloatingFocusManager,
-  FloatingNode,
-  FloatingPortal,
-  useDismiss,
-  useFloating,
-  useFloatingNodeId,
-  useInteractions,
-} from '@floating-ui/react'
+import { Dialog } from '@base-ui-components/react/dialog'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Sparkles, X } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
@@ -68,30 +60,16 @@ function AvailableBody({ markdown, selectedText }) {
 function ElaborationPreview({ isOpen, status, selectedText, markdown, errorMessage, onClose }) {
   const [isMounted, setIsMounted] = useState(isOpen)
   const closeButtonRef = useRef(null)
-  const nodeId = useFloatingNodeId()
 
   useEffect(() => {
     if (isOpen) setIsMounted(true)
   }, [isOpen])
 
-  const { refs, context } = useFloating({
-    nodeId,
-    open: isMounted,
-    onOpenChange: (open) => {
-      if (!open) onClose()
-    },
-  })
-  const dismiss = useDismiss(context, {
-    escapeKey: true,
-    outsidePress: true,
-  })
-  const { getFloatingProps } = useInteractions([dismiss])
-
   if (!isMounted) return null
 
   return (
-    <FloatingNode id={nodeId}>
-      <FloatingPortal>
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <Dialog.Portal>
         <AnimatePresence onExitComplete={() => setIsMounted(false)}>
           {isOpen && (
             <motion.div
@@ -102,50 +80,43 @@ function ElaborationPreview({ isOpen, status, selectedText, markdown, errorMessa
               exit={{ opacity: 0 }}
               transition={{ duration: 0.18 }}
             >
-              <div className="absolute inset-0 bg-slate-900/30 backdrop-blur-sm" />
-              <FloatingFocusManager
-                context={context}
-                modal={true}
-                returnFocus={true}
+              <Dialog.Backdrop className="absolute inset-0 bg-slate-900/30 backdrop-blur-sm" />
+              <Dialog.Popup
                 initialFocus={closeButtonRef}
+                finalFocus={closeButtonRef}
+                render={<motion.div />}
+                role="dialog"
+                aria-modal={true}
+                aria-label="Elaboration"
+                initial={{ opacity: 0, scale: 0.92 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.96 }}
+                transition={{ type: 'spring', stiffness: 320, damping: 28 }}
+                className="relative flex h-[60vh] w-[85vw] max-w-xl flex-col overflow-hidden rounded-3xl border border-white/60 bg-white/80 shadow-elevated backdrop-blur-2xl"
               >
-                <motion.div
-                  {...getFloatingProps({
-                    ref: refs.setFloating,
-                    role: 'dialog',
-                    'aria-modal': true,
-                    'aria-label': 'Elaboration',
-                    initial: { opacity: 0, scale: 0.92 },
-                    animate: { opacity: 1, scale: 1 },
-                    exit: { opacity: 0, scale: 0.96 },
-                    transition: { type: 'spring', stiffness: 320, damping: 28 },
-                    className: 'relative flex h-[60vh] w-[85vw] max-w-xl flex-col overflow-hidden rounded-3xl border border-white/60 bg-white/80 shadow-elevated backdrop-blur-2xl',
-                  })}
+                <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/80 to-transparent" />
+
+                <button
+                  ref={closeButtonRef}
+                  type="button"
+                  onClick={onClose}
+                  aria-label="Close"
+                  className="absolute right-3 top-3 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-white/70 text-slate-500 shadow-card backdrop-blur transition-colors hover:bg-white hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-400/60"
                 >
-                  <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/80 to-transparent" />
+                  <X size={15} />
+                </button>
 
-                  <button
-                    ref={closeButtonRef}
-                    type="button"
-                    onClick={onClose}
-                    aria-label="Close"
-                    className="absolute right-3 top-3 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-white/70 text-slate-500 shadow-card backdrop-blur transition-colors hover:bg-white hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-400/60"
-                  >
-                    <X size={15} />
-                  </button>
-
-                  {status === 'loading' && <LoadingBody selectedText={selectedText} />}
-                  {status === 'error' && <ErrorBody message={errorMessage} />}
-                  {status === 'available' && (
-                    <AvailableBody markdown={markdown} selectedText={selectedText} />
-                  )}
-                </motion.div>
-              </FloatingFocusManager>
+                {status === 'loading' && <LoadingBody selectedText={selectedText} />}
+                {status === 'error' && <ErrorBody message={errorMessage} />}
+                {status === 'available' && (
+                  <AvailableBody markdown={markdown} selectedText={selectedText} />
+                )}
+              </Dialog.Popup>
             </motion.div>
           )}
         </AnimatePresence>
-      </FloatingPortal>
-    </FloatingNode>
+      </Dialog.Portal>
+    </Dialog.Root>
   )
 }
 

--- a/client/src/components/OverlayContextMenu.jsx
+++ b/client/src/components/OverlayContextMenu.jsx
@@ -1,18 +1,6 @@
-import {
-  autoUpdate,
-  FloatingFocusManager,
-  FloatingNode,
-  FloatingPortal,
-  flip,
-  inline,
-  offset,
-  shift,
-  useDismiss,
-  useFloating,
-  useFloatingNodeId,
-  useInteractions,
-} from '@floating-ui/react'
-import { useCallback, useEffect, useMemo } from 'react'
+import { ContextMenu } from '@base-ui-components/react/context-menu'
+import { autoUpdate, flip, inline, offset, shift, useFloating } from '@floating-ui/react'
+import { useEffect, useMemo } from 'react'
 
 const MENU_EDGE_GAP_PX = 8
 
@@ -24,7 +12,6 @@ function createVirtualReference(positionReference) {
 }
 
 function OverlayContextMenu({ isOpen, positionReference, actions, onOpenChange, selectedText }) {
-  const nodeId = useFloatingNodeId()
   const isCoarsePointer = matchMedia('(pointer: coarse)').matches
 
   const middleware = useMemo(() => {
@@ -36,22 +23,14 @@ function OverlayContextMenu({ isOpen, positionReference, actions, onOpenChange, 
     return list
   }, [positionReference?.kind, positionReference?.offsetPx])
 
-  const { refs, floatingStyles, context } = useFloating({
-    nodeId,
+  const { refs, floatingStyles } = useFloating({
     open: isOpen,
-    onOpenChange,
     placement: positionReference?.placement ?? 'bottom-start',
     strategy: 'fixed',
     transform: false,
     whileElementsMounted: autoUpdate,
     middleware,
   })
-  const dismiss = useDismiss(context, {
-    escapeKey: true,
-    outsidePress: true,
-    outsidePressEvent: isCoarsePointer ? 'click' : 'pointerdown',
-  })
-  const { getFloatingProps } = useInteractions([dismiss])
 
   const virtualReference = useMemo(
     () => positionReference ? createVirtualReference(positionReference) : null,
@@ -62,49 +41,42 @@ function OverlayContextMenu({ isOpen, positionReference, actions, onOpenChange, 
     refs.setPositionReference(virtualReference)
   }, [refs, virtualReference])
 
-  const setMenuNode = useCallback((node) => {
-    refs.setFloating(node)
-  }, [refs])
-
   if (!isOpen) return null
 
   function handleActionClick(action) {
     if (action.disabled) return
 
     const text = selectedText || window.getSelection()?.toString() || ''
-    console.log('[ctxmenu] action click — key:', action.key, '| text:', text.slice(0, 40), '| live:', window.getSelection()?.toString()?.slice(0, 40))
     window.getSelection()?.removeAllRanges()
     onOpenChange(false)
     action.onSelect(text)
   }
 
   return (
-    <FloatingNode id={nodeId}>
-      <FloatingPortal>
-        <FloatingFocusManager
-          context={context}
-          modal={false}
-          initialFocus={isCoarsePointer ? -1 : 0}
-          returnFocus={!isCoarsePointer}
+    <ContextMenu.Root open={isOpen} onOpenChange={onOpenChange} modal={false}>
+      <ContextMenu.Portal>
+        <ContextMenu.Positioner
+          sideOffset={0}
+          style={floatingStyles}
+          className="fixed z-[150]"
+          ref={refs.setFloating}
         >
-          <div
-            {...getFloatingProps({
-              ref: setMenuNode,
-              role: 'menu',
-              'aria-label': 'Reading actions',
-              onClick: (event) => event.stopPropagation(),
-              onContextMenu: (event) => event.preventDefault(),
-              className: 'fixed z-[150] w-[184px] overflow-hidden rounded-2xl border border-slate-200/80 bg-white/95 p-1.5 text-slate-700 shadow-elevated backdrop-blur-xl motion-safe:animate-overlay-menu-enter',
-              style: floatingStyles,
-            })}
+          <ContextMenu.Popup
+            role="menu"
+            aria-label="Reading actions"
+            onClick={(event) => event.stopPropagation()}
+            onContextMenu={(event) => event.preventDefault()}
+            className="w-[184px] overflow-hidden rounded-2xl border border-slate-200/80 bg-white/95 p-1.5 text-slate-700 shadow-elevated backdrop-blur-xl motion-safe:animate-overlay-menu-enter"
           >
             {actions.map((action) => (
-              <button
+              <ContextMenu.Item
                 key={action.key}
-                type="button"
-                role="menuitem"
                 disabled={action.disabled}
-                onClick={() => handleActionClick(action)}
+                closeOnSelect={!isCoarsePointer}
+                onSelect={(event) => {
+                  event.preventDefault()
+                  handleActionClick(action)
+                }}
                 className={[
                   'flex w-full items-center gap-2.5 rounded-xl px-3 py-2.5 text-left text-sm font-medium transition-colors',
                   'hover:bg-slate-100 focus:bg-slate-100 focus:outline-none disabled:opacity-40',
@@ -115,12 +87,12 @@ function OverlayContextMenu({ isOpen, positionReference, actions, onOpenChange, 
                   {action.icon}
                 </span>
                 <span>{action.label}</span>
-              </button>
+              </ContextMenu.Item>
             ))}
-          </div>
-        </FloatingFocusManager>
-      </FloatingPortal>
-    </FloatingNode>
+          </ContextMenu.Popup>
+        </ContextMenu.Positioner>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
   )
 }
 

--- a/client/src/components/OverlayContextMenu.jsx
+++ b/client/src/components/OverlayContextMenu.jsx
@@ -1,6 +1,6 @@
 import { ContextMenu } from '@base-ui-components/react/context-menu'
 import { autoUpdate, flip, inline, offset, shift, useFloating } from '@floating-ui/react'
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 const MENU_EDGE_GAP_PX = 8
 
@@ -41,6 +41,11 @@ function OverlayContextMenu({ isOpen, positionReference, actions, onOpenChange, 
     refs.setPositionReference(virtualReference)
   }, [refs, virtualReference])
 
+  const handleMenuOpenChange = useCallback((open, eventDetails) => {
+    const reason = eventDetails?.reason === 'outside-press' ? 'outside-press' : undefined
+    onOpenChange(open, eventDetails?.event, reason)
+  }, [onOpenChange])
+
   if (!isOpen) return null
 
   function handleActionClick(action) {
@@ -53,7 +58,7 @@ function OverlayContextMenu({ isOpen, positionReference, actions, onOpenChange, 
   }
 
   return (
-    <ContextMenu.Root open={isOpen} onOpenChange={onOpenChange} modal={false}>
+    <ContextMenu.Root open={isOpen} onOpenChange={handleMenuOpenChange} modal={false}>
       <ContextMenu.Portal>
         <ContextMenu.Positioner
           sideOffset={0}


### PR DESCRIPTION
### Motivation
- Replace bespoke Floating UI focus/dismiss wiring with BaseUI primitives for the overlay menu and dialog to standardize behavior while keeping external APIs unchanged.
- Keep wrapper components as the single source-of-truth for open/close state and action handlers to avoid churn in callers.
- Preserve mobile selection behavior driven by the `positionReference` shape so coarse-pointer selection does not collapse unexpectedly.
- Leave `BaseOverlay` and gesture subsystems untouched in this phase to keep orchestration and Zen/Digest parity stable.

### Description
- Replaced internal floating/focus/dismiss implementation in `client/src/components/OverlayContextMenu.jsx` with `ContextMenu` primitives from `@base-ui-components/react` while retaining `isOpen`, `positionReference`, `actions`, `onOpenChange`, and `selectedText` props and continuing to use `useFloating` for positioning.
- Replaced internal floating/focus/dismiss implementation in `client/src/components/ElaborationPreview.jsx` with `Dialog` primitives from `@base-ui-components/react` while keeping the existing `isOpen` mount/unmount lifecycle and routing close events through the wrapper `onClose` callback and `AnimatePresence` animations.
- Kept `client/src/components/BaseOverlay.jsx` unchanged as the orchestration shell so Zen and Digest overlays still share the same `overlayMenu` shape and close semantics.
- Added the BaseUI package dependency to `client/package.json` and updated `client/package-lock.json` to include the new packages.

### Testing
- Ran `cd client && npm run build` and the Vite production build completed successfully.
- Verified the client build artifacts were produced (bundle build completed despite chunk-size warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a8e94d088332aaf49d2e717a20f8)