### PR TITLE
Use UTC day epoch bounds for Hacker News Algolia queries

### DIFF
--- a/adapters/hackernews_adapter.py
+++ b/adapters/hackernews_adapter.py
@@ -1,7 +1,6 @@
 """Hacker News adapter that fetches Show HN stories for a specific date."""
 
 import logging
-from datetime import datetime
 
 from adapters.newsletter_adapter import NewsletterAdapter
 import util
@@ -22,13 +21,12 @@ class HackerNewsAdapter(NewsletterAdapter):
 
     def scrape_date(self, date: str, excluded_urls: list[str]) -> dict:
         """Fetch and normalize Show HN stories for a date."""
-        target_date = datetime.fromisoformat(util.format_date_for_url(date))
-        start_of_day = target_date.replace(hour=0, minute=0, second=0, microsecond=0)
-        end_of_day = target_date.replace(hour=23, minute=59, second=59, microsecond=0)
+        date_str = util.format_date_for_url(date)
+        start_timestamp, end_timestamp_exclusive = util.utc_day_epoch_seconds_bounds(date_str)
 
         stories = self._fetch_stories_algolia(
-            start_timestamp=int(start_of_day.timestamp()),
-            end_timestamp=int(end_of_day.timestamp()),
+            start_timestamp=start_timestamp,
+            end_timestamp=end_timestamp_exclusive,
             min_points=self.min_points,
             min_comments=self.min_comments,
             limit=self.max_stories,
@@ -43,7 +41,7 @@ class HackerNewsAdapter(NewsletterAdapter):
             canonical_url = util.canonicalize_url(url)
             if canonical_url in excluded_set:
                 continue
-            article = self._algolia_story_to_article(story, date)
+            article = self._algolia_story_to_article(story, date_str)
             if article:
                 articles.append(article)
 

--- a/util.py
+++ b/util.py
@@ -2,7 +2,7 @@ import functools
 import logging
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 import requests
@@ -72,6 +72,26 @@ def next_day_midnight_pacific_epoch_seconds(date_str: str) -> float:
         0, 0, 0, tzinfo=PACIFIC_TZ
     )
     return next_day_midnight_pacific.timestamp()
+
+
+def utc_day_epoch_seconds_bounds(date_str: str) -> tuple[int, int]:
+    """Return [start, end) epoch seconds bounds for a UTC calendar day.
+
+    >>> utc_day_epoch_seconds_bounds("2025-01-23")
+    (1737590400, 1737676800)
+    """
+    target_date = datetime.fromisoformat(date_str)
+    start_of_day_utc = datetime(
+        target_date.year,
+        target_date.month,
+        target_date.day,
+        0,
+        0,
+        0,
+        tzinfo=timezone.utc,
+    )
+    end_of_day_utc_exclusive = start_of_day_utc + timedelta(days=1)
+    return int(start_of_day_utc.timestamp()), int(end_of_day_utc_exclusive.timestamp())
 
 
 def should_rescrape(date_str: str, cached_at_epoch_seconds: float | None) -> bool:


### PR DESCRIPTION
### Motivation

- Ensure Algolia queries target a full UTC calendar day rather than local/Pacific-derived timestamps to match HN/Algolia time semantics.  
- Normalize the date value passed to downstream article conversion to a URL-safe string to avoid inconsistent formatting.

### Description

- Replaced per-module `datetime` logic in `adapters/hackernews_adapter.py` with `util.utc_day_epoch_seconds_bounds` and removed unused `datetime` import.  
- Updated `_fetch_stories_algolia` calls to use the `start_timestamp` and exclusive `end_timestamp` returned by `utc_day_epoch_seconds_bounds`.  
- Pass the formatted `date_str` (from `util.format_date_for_url`) into `_algolia_story_to_article` instead of the original `date` input.  
- Added `utc_day_epoch_seconds_bounds` to `util.py`, implemented with timezone-aware UTC datetimes and returning integer epoch seconds for `[start, end)` bounds, and imported `timezone` for correct tz handling.

### Testing

- Ran the project's `pytest` unit test suite and the `util.py` doctests, and they passed.  
- Verified the modified `HackerNewsAdapter` Algolia query parameters are constructed without runtime errors via unit/integration tests, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a4d14798833282c16d3747f2ddd5)