### PR TITLE
Refactor ToastContainer to BaseUI provider/viewport model

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@base-ui/react": "^1.4.1",
         "@floating-ui/react": "^0.27.19",
         "dompurify": "^3.3.0",
         "framer-motion": "^11.15.0",
@@ -279,6 +280,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -325,6 +335,66 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui/react": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.1.tgz",
+      "integrity": "sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.2.8",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {
@@ -1914,7 +1984,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2131,7 +2201,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3145,6 +3215,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -3376,6 +3452,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "lint": "./scripts/lint.sh"
   },
   "dependencies": {
+    "@base-ui/react": "^1.4.1",
     "@floating-ui/react": "^0.27.19",
     "dompurify": "^3.3.0",
     "framer-motion": "^11.15.0",

--- a/client/src/components/ToastContainer.jsx
+++ b/client/src/components/ToastContainer.jsx
@@ -1,53 +1,48 @@
+import { Toast } from '@base-ui/react/toast'
 import { CheckCircle } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { useEffect, useState } from 'react'
 import { subscribeToToasts } from '../lib/toastBus'
 
 const TOAST_VISIBLE_MS = 12000
-const EXIT_ANIMATION_MS = 350
 
-function Toast({ id, title, onOpen, onDismiss }) {
-  const [exiting, setExiting] = useState(false)
-
-  useEffect(() => {
-    const exitTimer = setTimeout(() => setExiting(true), TOAST_VISIBLE_MS - EXIT_ANIMATION_MS)
-    const removeTimer = setTimeout(() => onDismiss(id), TOAST_VISIBLE_MS)
-    return () => {
-      clearTimeout(exitTimer)
-      clearTimeout(removeTimer)
-    }
-  }, [id, onDismiss])
-
-  const handleClick = () => {
-    onOpen?.()
-    onDismiss(id)
-  }
-
+function ToastItem({ id, title, onOpen, onDismiss }) {
   return (
-    <div
-      onClick={handleClick}
-      className={`
-        relative overflow-hidden
-        flex items-center gap-3
-        bg-gradient-to-r from-brand-50/95 to-white/95 text-slate-900
-        px-4 py-3.5 rounded-2xl
-        border border-brand-200/70
-        ring-1 ring-brand-100/80
-        shadow-elevated backdrop-blur-sm
-        max-w-md w-full
-        pointer-events-auto cursor-pointer
-        ${exiting ? 'animate-toast-out' : 'animate-toast-in'}
-      `}
+    <Toast.Root
+      defaultOpen
+      onOpenChange={(open) => {
+        if (!open) onDismiss(id)
+      }}
+      className="group pointer-events-auto max-w-md w-full"
     >
-      <span className="absolute inset-y-0 left-0 w-1.5 bg-brand-300/80" />
-      <span className="ml-2 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-700">
-        <CheckCircle size={16} />
-      </span>
-      <div className="min-w-0 flex-1">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-brand-700/90">Summary ready</p>
-        <p className="text-base font-semibold text-slate-800 truncate">{title}</p>
-      </div>
-    </div>
+      <Toast.Close className="sr-only">Dismiss toast</Toast.Close>
+      <Toast.Description
+        onClick={() => {
+          onOpen?.()
+          onDismiss(id)
+        }}
+        className="
+          relative overflow-hidden
+          flex items-center gap-3
+          bg-gradient-to-r from-brand-50/95 to-white/95 text-slate-900
+          px-4 py-3.5 rounded-2xl
+          border border-brand-200/70
+          ring-1 ring-brand-100/80
+          shadow-elevated backdrop-blur-sm
+          cursor-pointer
+          animate-toast-in
+          data-[ending-style]:animate-toast-out
+        "
+      >
+        <span className="absolute inset-y-0 left-0 w-1.5 bg-brand-300/80" />
+        <span className="ml-2 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-700">
+          <CheckCircle size={16} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-brand-700/90">Summary ready</p>
+          <p className="text-base font-semibold text-slate-800 truncate">{title}</p>
+        </div>
+      </Toast.Description>
+    </Toast.Root>
   )
 }
 
@@ -61,16 +56,18 @@ export default function ToastContainer() {
     })
   }), [])
 
-  const dismiss = useCallback((id) => setToasts(prev => prev.filter(t => t.id !== id)), [])
-
   if (toasts.length === 0) return null
 
-  return createPortal(
-    <div className="fixed top-4 left-0 right-0 z-[300] flex flex-col items-center gap-2.5 pointer-events-none px-4">
-      {toasts.map(toast => (
-        <Toast key={toast.id} {...toast} onDismiss={dismiss} />
+  return (
+    <Toast.Provider timeout={TOAST_VISIBLE_MS}>
+      {toasts.map((toast) => (
+        <ToastItem
+          key={toast.id}
+          {...toast}
+          onDismiss={(id) => setToasts(previousToasts => previousToasts.filter((item) => item.id !== id))}
+        />
       ))}
-    </div>,
-    document.body
+      <Toast.Viewport className="fixed top-4 left-0 right-0 z-[300] flex flex-col items-center gap-2.5 pointer-events-none px-4" />
+    </Toast.Provider>
   )
 }


### PR DESCRIPTION
### Motivation
- Keep the existing `toastBus` publish API surface so emitters do not need to change. 
- Replace bespoke internal timer/stacking logic with a maintained toast primitives model to reduce complexity and delegate lifecycle/viewport concerns. 
- Preserve the current UX and visual language constraints (max two visible toasts, click-to-open behavior, 12s auto-dismiss, and existing Tailwind tokens/classes).

### Description
- Replaced manual per-toast timers, exit animation orchestration and portal stacking with Base UI toast primitives (`Toast.Provider`, `Toast.Root`, `Toast.Description`, `Toast.Viewport`) inside `client/src/components/ToastContainer.jsx`. 
- Left the `toastBus` pub/sub API unchanged in `client/src/lib/toastBus.js` so upstream callers remain compatible. 
- Continued to enforce a maximum of two visible toasts via the existing `slice(-2)` logic and preserved click-to-open behavior by forwarding the existing `onOpen` callback. 
- Kept the current Tailwind classes/tokens on the new Base UI elements and added the `@base-ui/react` dependency with lockfile updates in `client/package.json` and `client/package-lock.json`.

### Testing
- Built the frontend with `npm --prefix client run build` and the build completed successfully. 
- Performed automated code searches for `toastBus`/`ToastContainer` to verify no upstream emitter changes were required and that `useSummary` still calls `emitToast`. 
- Verified the app bundle builds with the new dependency (no runtime changes to `emitToast` callsites were required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c1903aa08332bc9e6cdebfbb1958)