### PR TITLE
Refactor FoldableContainer to use Base UI Collapsible primitive

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@base-ui/react": "^1.4.1",
         "@floating-ui/react": "^0.27.19",
         "dompurify": "^3.3.0",
         "framer-motion": "^11.15.0",
@@ -279,6 +280,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -325,6 +335,66 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui/react": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.1.tgz",
+      "integrity": "sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.2.8",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {
@@ -1914,7 +1984,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2131,7 +2201,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3145,6 +3215,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -3376,6 +3452,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "lint": "./scripts/lint.sh"
   },
   "dependencies": {
+    "@base-ui/react": "^1.4.1",
     "@floating-ui/react": "^0.27.19",
     "dompurify": "^3.3.0",
     "framer-motion": "^11.15.0",

--- a/client/src/components/FoldableContainer.jsx
+++ b/client/src/components/FoldableContainer.jsx
@@ -1,3 +1,4 @@
+import { Collapsible } from '@base-ui/react/collapsible'
 import { ChevronRight } from 'lucide-react'
 import { useEffect } from 'react'
 import { useInteraction } from '../contexts/InteractionContext'
@@ -14,14 +15,15 @@ function FoldableContainer({ id, title, children, defaultFolded = false, classNa
   }, [defaultFolded, id, setExpanded])
 
   return (
-    <div
+    <Collapsible.Root
+      open={expanded}
+      onOpenChange={() => containerShortPress(id)}
       data-is-folded={isFolded}
       {...dataAttributes}
       className={`transition-all duration-300 ${className}`}
     >
       <div className={`flex items-center ${headerClassName}`}>
-        <div
-          onClick={() => containerShortPress(id)}
+        <Collapsible.Trigger
           data-fold-toggle
           className="cursor-pointer group select-none flex items-center flex-1"
         >
@@ -35,18 +37,20 @@ function FoldableContainer({ id, title, children, defaultFolded = false, classNa
           `}>
             <ChevronRight size={18} />
           </div>
-        </div>
+        </Collapsible.Trigger>
       </div>
 
-      <div className={`
-        grid transition-all duration-500 ease-in-out
-        ${isFolded ? 'grid-rows-[0fr] opacity-0' : 'grid-rows-[1fr] opacity-100'}
-      `}>
+      <Collapsible.Panel
+        className={`
+          grid transition-all duration-500 ease-in-out
+          ${isFolded ? 'grid-rows-[0fr] opacity-0' : 'grid-rows-[1fr] opacity-100'}
+        `}
+      >
         <div className={`overflow-hidden ${contentClassName}`}>
-           {children}
+          {children}
         </div>
-      </div>
-    </div>
+      </Collapsible.Panel>
+    </Collapsible.Root>
   )
 }
 


### PR DESCRIPTION
### Motivation
- Replace the component's internal toggle/ARIA mechanics with a proven disclosure primitive to reduce bespoke interaction code while keeping public behavior stable.
- Keep expansion state authoritative in `InteractionContext` so the UI primitive is a view-only layer and not a new owner of state.
- Preserve existing DOM hooks and attributes relied on by downstream code and styles (`data-is-folded`, `data-fold-toggle`) to avoid regressions.

### Description
- Replaced the root `div` and manual trigger/panel in `client/src/components/FoldableContainer.jsx` with `Collapsible.Root`, `Collapsible.Trigger` and `Collapsible.Panel` from `@base-ui/react/collapsible` while keeping the component props unchanged and preserving `data-is-folded` and `data-fold-toggle` attributes.
- Wired `open={expanded}` to the `InteractionContext` via `isExpanded(id)` and forwarded user toggles to `containerShortPress(id)` in the `onOpenChange` handler so expansion remains sourced from `InteractionContext`.
- Kept the original Tailwind transition classes and chevron rotation logic so the visual timing and keyboard/click feel remain intact.
- Added `@base-ui/react` to `client/package.json` and updated `client/package-lock.json` to include the new dependency.

### Testing
- Ran `./setup.sh` which completed without blocking errors and prepared the workspace for the change (success).
- Ran `cd client && npm run build` which completed successfully producing a production build (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c1a5e658833282c13e959d9067ed)