### PR TITLE
Use source-specific favicons in ArticleCard and add sourceLogoMap

### DIFF
--- a/client/src/components/ArticleCard.jsx
+++ b/client/src/components/ArticleCard.jsx
@@ -7,6 +7,7 @@ import { useArticleState } from '../hooks/useArticleState'
 import { useSummary } from '../hooks/useSummary'
 import { useSwipeToRemove } from '../hooks/useSwipeToRemove'
 import { subscribeToArticleAction } from '../lib/articleActionBus'
+import { getSourceLogo } from '../lib/sourceLogoMap'
 import Selectable from './Selectable'
 import ZenModeOverlay from './ZenModeOverlay'
 
@@ -40,16 +41,20 @@ function ArticleTitle({ isRead, title }) {
   )
 }
 
-function ArticleMeta({ domain, hostname, articleMeta }) {
+function ArticleMeta({ sourceId, domain, articleMeta }) {
+  const sourceLogo = getSourceLogo(sourceId)
+
   return (
     <div className="flex items-center gap-2 min-w-0">
-      {hostname && (
+      {sourceLogo && (
         <div className="w-4 h-4 rounded-full bg-white border border-slate-200 overflow-hidden flex items-center justify-center shrink-0">
           <img
-            src={`https://www.google.com/s2/favicons?domain=${hostname}&sz=64`}
+            src={sourceLogo}
             alt={domain}
-            className="w-full h-full object-cover"
-            onError={(e) => { e.target.style.display = 'none' }}
+            className="w-full h-full object-contain"
+            loading="lazy"
+            decoding="async"
+            onError={(event) => { event.currentTarget.style.visibility = 'hidden' }}
           />
         </div>
       )}
@@ -211,8 +216,8 @@ function ArticleCard({ article }) {
 
               {!isRemoved && (
                 <ArticleMeta
+                  sourceId={article.sourceId}
                   domain={displayDomain}
-                  hostname={hostname}
                   articleMeta={article.articleMeta}
                 />
               )}

--- a/client/src/lib/sourceLogoMap.js
+++ b/client/src/lib/sourceLogoMap.js
@@ -1,0 +1,33 @@
+const sourceHosts = {
+  tldr_tech: 'tldr.tech',
+  tldr_ai: 'tldr.tech',
+  hackernews: 'news.ycombinator.com',
+  xeiaso: 'xeiaso.net',
+  simon_willison: 'simonwillison.net',
+  danluu: 'danluu.com',
+  will_larson: 'lethain.com',
+  pragmatic_engineer: 'newsletter.pragmaticengineer.com',
+  jessitron: 'jessitron.com',
+  stripe_engineering: 'stripe.com',
+  deepmind: 'deepmind.google',
+  google_research: 'research.google',
+  pointer: 'pointer.io',
+  netflix: 'medium.com',
+  anthropic: 'anthropic.com',
+  anthropic_news: 'anthropic.com',
+  claude_blog: 'claude.com',
+  softwareleadweekly: 'softwareleadweekly.com',
+  hillel_wayne: 'hillelwayne.com',
+  martin_fowler: 'martinfowler.com',
+  react_status: 'statuscode.com',
+  aiwithmike: 'aiwithmike.substack.com',
+  savannah_ostrowski: 'savannah.dev',
+  lucumr: 'lucumr.pocoo.org',
+  trendshift: 'trendshift.io',
+}
+
+export function getSourceLogo(sourceId) {
+  const hostname = sourceHosts[sourceId]
+  if (!hostname) return null
+  return `https://www.google.com/s2/favicons?domain=${hostname}&sz=64`
+}


### PR DESCRIPTION
### Motivation

- Ensure article cards show consistent, source-specific favicons instead of relying on a hostname field. 
- Provide a central mapping of known source IDs to hostnames so favicons can be resolved reliably. 

### Description

- Added `client/src/lib/sourceLogoMap.js` which exports `getSourceLogo(sourceId)` and maps known `sourceId` values to hostnames used for favicon URLs. 
- Updated `ArticleCard.jsx` to pass `article.sourceId` into `ArticleMeta`. 
- Modified `ArticleMeta` to accept `sourceId`, call `getSourceLogo`, and render the favicon using the resolved URL when available. 
- Improved image attributes and error handling by switching to `object-contain`, adding `loading="lazy"` and `decoding="async"`, and hiding the image via `event.currentTarget.style.visibility = 'hidden'` on error. 

### Testing

- Ran unit tests with `yarn test`, and they completed successfully. 
- Ran linting with `yarn lint`, and no lint errors were reported. 
- Verified a local production build with `yarn build` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c302d9d88332bf86a8fd6c8d08d9)