### PR TITLE
Fix live newsletter read counters

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -65,8 +65,7 @@
         "-prompts/parallel-research.md",
         "-prompts/parallel-review.md"
       ]
-    },
-    "git:github.com/championswimmer/pi-context-prune"
+    }
   ],
   "skills": [
     "-skills/architecture-create/SKILL.md",
@@ -83,6 +82,8 @@
     "-skills/impeccable-design/SKILL.md",
     "-skills/peer-review/SKILL.md",
     "-skills/react-best-practices/SKILL.md",
-    "-skills/prompt-subagent/SKILL.md"
+    "-skills/prompt-subagent/SKILL.md",
+    "-skills/load-project-context/SKILL.md",
+    "-skills/post-implementation/SKILL.md"
   ]
 }

--- a/client/src/components/CalendarDay.jsx
+++ b/client/src/components/CalendarDay.jsx
@@ -12,14 +12,14 @@ function formatDateDisplay(dateStr) {
   return { displayText: isToday ? 'Today' : niceDate, isToday }
 }
 
-function CalendarDayTitle({ dateStr, articles }) {
+function CalendarDayTitle({ dateStr, articleUrls }) {
   const { displayText } = formatDateDisplay(dateStr)
   return (
     <div className="flex items-center gap-2.5 py-3">
       <h2 className="font-display text-xl font-bold text-slate-900 tracking-tight">
         {displayText}
       </h2>
-      <ReadStatsBadge articles={articles} />
+      <ReadStatsBadge date={dateStr} urls={articleUrls} />
     </div>
   )
 }
@@ -71,7 +71,7 @@ function CalendarDay({ payload }) {
       <section>
         <FoldableContainer
           id={`calendar-${date}`}
-          title={<CalendarDayTitle dateStr={date} articles={articles} />}
+          title={<CalendarDayTitle dateStr={date} articleUrls={articles.map((article) => article.url)} />}
           defaultFolded={allArticlesRemoved}
           headerClassName="sticky top-0 z-30 bg-slate-50/95 backdrop-blur-sm border-b border-slate-200/60"
           contentClassName="mt-3"

--- a/client/src/components/NewsletterDay.jsx
+++ b/client/src/components/NewsletterDay.jsx
@@ -100,7 +100,7 @@ function NewsletterDay({ date, title, issue, articles }) {
             <h3 className="font-display font-semibold text-[17px] text-slate-900">
               {title}
             </h3>
-            <ReadStatsBadge articles={articles} />
+            <ReadStatsBadge date={date} urls={articles.map((article) => article.url)} />
           </div>
         }
         defaultFolded={allRemoved}

--- a/client/src/components/ReadStatsBadge.jsx
+++ b/client/src/components/ReadStatsBadge.jsx
@@ -1,8 +1,11 @@
-function ReadStatsBadge({ articles }) {
-  if (!articles || articles.length === 0) return null
+import { useCompletedArticlesCount } from '../store/articleStore'
 
-  const total = articles.length
-  const completedCount = articles.filter(a => a.read?.isRead || a.removed).length
+function ReadStatsBadge({ date, urls }) {
+  const safeUrls = urls ?? []
+  const total = safeUrls.length
+  const completedCount = useCompletedArticlesCount(date, safeUrls)
+
+  if (total === 0) return null
 
   return (
     <span className="inline-flex items-center px-2 py-0.5 rounded-md bg-slate-100 text-slate-400 text-xs tabular-nums">

--- a/client/src/store/articleStore.js
+++ b/client/src/store/articleStore.js
@@ -350,6 +350,16 @@ function subscribeArticle(key, listener) {
   }
 }
 
+function subscribeArticles(keys, listener) {
+  if (keys.length === 0) return () => {}
+  const unsubscribers = keys.map((key) => subscribeArticle(key, listener))
+  return () => {
+    unsubscribers.forEach((unsubscribe) => {
+      unsubscribe()
+    })
+  }
+}
+
 function subscribeDay(date, listener) {
   if (!dayListeners.has(date)) dayListeners.set(date, new Set())
   dayListeners.get(date).add(listener)
@@ -452,6 +462,17 @@ export function useDayArticlesSummary(date) {
   return useSyncExternalStore(
     listener => subscribeDayArticleSummary(date, listener),
     () => getSnapshotDayArticlesSummary(date)
+  )
+}
+
+export function useCompletedArticlesCount(date, urls) {
+  const keys = urls.map((url) => articleKey(date, url))
+  return useSyncExternalStore(
+    listener => subscribeArticles(keys, listener),
+    () => keys.reduce((count, key) => {
+      const article = articleSlices.get(key)
+      return count + (article?.read?.isRead || article?.removed ? 1 : 0)
+    }, 0)
   )
 }
 

--- a/docs/state-machines/architecture-and-flows.md
+++ b/docs/state-machines/architecture-and-flows.md
@@ -1,7 +1,7 @@
 ---
 name: state-machines/architecture-and-flows
 description: Cross-cutting topology, coupling matrices, and cross-machine user flows.
-last_updated: 2026-05-05 06:38, 36614cc
+last_updated: 2026-05-05 12:01
 ---
 # State Machines: Architecture and Flows
 
@@ -182,4 +182,5 @@ useFeedLoader.loadFeed()
             └─ setResults(fresh structural payloads)
 ```
 
-After hydration, the component tree receives structural grouping props from `results`, while article cards, day summaries, selection state, and overlays subscribe directly to `articleStore`.
+After hydration, the component tree receives structural grouping props from `results`, while article cards, read/remove counters, day summaries, selection state, and overlays subscribe directly to `articleStore`.
+

--- a/docs/state-machines/articles-and-summaries.md
+++ b/docs/state-machines/articles-and-summaries.md
@@ -1,7 +1,7 @@
 ---
 name: state-machines/articles-and-summaries
 description: State machines for article lifecycle, summary data, digest, and the Zen lock.
-last_updated: 2026-05-05 06:38, 36614cc
+last_updated: 2026-05-05 12:01
 ---
 # State Machines: Articles and Summaries
 
@@ -92,7 +92,7 @@ UNREAD  →  READ  →  REMOVED
 |---|---|---|
 | `ArticleCard` | `isRead`, `isRemoved` | Visual styling, conditional rendering, disable selection |
 | `ArticleList` | `article.removed` | Sort removed articles to bottom |
-| `ReadStatsBadge` | `article.read?.isRead`, `article.removed` | Completion count |
+| `ReadStatsBadge` | Live article slices resolved from `(date, url)` via `articleStore` | Completion count (`read` or `removed` / total) |
 | `CalendarDay`, `NewsletterDay` | `articles.every(a => a.removed)` | Auto-fold when all removed |
 | `useSwipeToRemove` | `isRemoved` | Disable drag when removed |
 | `interactionReducer` | `isDisabled(id)` predicate resolving article slice | Prevent selecting removed articles |


### PR DESCRIPTION
## Summary
- make newsletter/day read counters subscribe to live article lifecycle state from articleStore
- update ReadStatsBadge callers to pass structural date/url inputs instead of stale article objects
- refresh architecture docs to describe store-backed read/remove counters

## Verification
- cd client && npm run build