### PR TITLE
fix(client): make newsletter counter and all-removed visuals reactive

### DIFF
--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -1,9 +1,22 @@
 ---
-last_updated: 2026-05-03 15:10, bb6b54a
+last_updated: 2026-05-05 14:05
+what_is_a_gotcha: Rather confidently signing off on something that later on proved to be at least partially wrong due to wrong assumptions; Figuratively, going thourhg "[allegedly] fixed" -> "oh actually it's not fixed" -> "ahh right... fixed now".
 ---
 # Gotchas
 
 This document catalogs recurring pitfalls in various topics, including managing client-side state persistence and reactivity, surprising design decisions, and so on.
+
+---
+
+#### 2026-05-05: Derived multi-article UI can still go stale after a "store-backed" fix if the subscription shape is wrong
+
+**Desired behavior that didn't work**: After fixing the newsletter/day `n/m` badge to read completion from `articleStore`, removing or reading an article should immediately update the badge and any all-removed visuals (newsletter/section dimming + auto-fold).
+
+**What actually happened and falsified original thesis**: We initially signed off on the badge fix because the implementation had been moved off structural props and onto store state. That confidence was premature. In a real repro (`HN Show` going from `1/2` to all removed), the last article dimmed, the newsletter collapsed, but the badge stayed at `1/2`. We had wrongly assumed that "subscribing to the relevant article keys" was automatically enough to make a multi-article derived UI reliable.
+
+**Cause & Fix**: The first fix subscribed the badge through a render-time-derived set of per-article listeners. That subscription shape was brittle for `useSyncExternalStore`: it depended on a recreated key collection/subscribe closure rather than a stable lifecycle signal. At the same time, newsletter and section `allRemoved` logic was still reading structural `articles.every(a => a.removed)` props instead of live lifecycle state. The durable fix was to add a day-level lifecycle notification path in `articleStore`, then expose selectors that derive grouped state from live slices for a given `(date, urls)` set: `useCompletedArticlesCount(date, urls)` and `useAllArticlesRemoved(date, urls)`. The badge, newsletter containers, and section containers now all use those selectors.
+
+**Generalized principle**: in external-store React code, "derived from the store" is not enough. The subscription boundary itself must match the semantic domain of the UI you are deriving. For grouped UI (badge counts, all-removed container state), prefer a stable grouped lifecycle selector over ad-hoc render-time fan-out subscriptions or structural prop scans.
 
 ---
 

--- a/client/src/components/NewsletterDay.jsx
+++ b/client/src/components/NewsletterDay.jsx
@@ -1,3 +1,4 @@
+import { useAllArticlesRemoved } from '../store/articleStore'
 import ArticleList from './ArticleList'
 import FoldableContainer from './FoldableContainer'
 import ReadStatsBadge from './ReadStatsBadge'
@@ -43,7 +44,8 @@ function SectionTitle({ displayTitle }) {
 }
 
 function Section({ date, sourceId, newsletterTitle, sectionKey, articles }) {
-  const allRemoved = articles.every(a => a.removed)
+  const articleUrls = articles.map((article) => article.url)
+  const allRemoved = useAllArticlesRemoved(date, articleUrls)
   const sectionEmoji = articles[0].sectionEmoji
   const displayTitle = sectionEmoji ? `${sectionEmoji} ${sectionKey}` : sectionKey
   const componentId = `section-${date}-${sourceId}-${sectionKey}`
@@ -81,7 +83,8 @@ function SectionsList({ date, sourceId, title, sections, sortedSectionKeys }) {
 }
 
 function NewsletterDay({ date, title, issue, articles }) {
-  const allRemoved = articles.length > 0 && articles.every(a => a.removed)
+  const articleUrls = articles.map((article) => article.url)
+  const allRemoved = useAllArticlesRemoved(date, articleUrls)
   const hasSections = articles.some(a => a.section)
 
   const sections = hasSections ? groupArticlesBySection(articles) : {}
@@ -100,7 +103,7 @@ function NewsletterDay({ date, title, issue, articles }) {
             <h3 className="font-display font-semibold text-[17px] text-slate-900">
               {title}
             </h3>
-            <ReadStatsBadge date={date} urls={articles.map((article) => article.url)} />
+            <ReadStatsBadge date={date} urls={articleUrls} />
           </div>
         }
         defaultFolded={allRemoved}

--- a/client/src/store/articleStore.js
+++ b/client/src/store/articleStore.js
@@ -19,6 +19,7 @@ const urlToArticleKey = new Map() // url → most-recent articleKey (for O(1) se
 const articleListeners = new Map()    // articleKey → Set<() => void>
 const dayListeners = new Map()        // date → Set<() => void>
 const dayArticleSummaryListeners = new Map() // date → Set<() => void>
+const dayLifecycleListeners = new Map() // date → Set<() => void>
 const containerListeners = new Map()  // containerId → Set<() => void>
 const anySelectedListeners = new Set()
 
@@ -36,6 +37,12 @@ function notifyDay(date) {
 
 function notifyDayArticleSummary(date) {
   dayArticleSummaryListeners.get(date)?.forEach(listener => {
+    listener()
+  })
+}
+
+function notifyDayLifecycle(date) {
+  dayLifecycleListeners.get(date)?.forEach(listener => {
     listener()
   })
 }
@@ -156,6 +163,7 @@ function ingestPayload(date, payload, notifyListeners) {
   const changedArticleKeys = []
   const nextArticleKeys = new Set()
   let selectedAggregateChanged = false
+  let dayLifecycleChanged = false
 
   payload.articles.forEach((article, index) => {
     const key = articleKey(date, article.url)
@@ -171,7 +179,15 @@ function ingestPayload(date, payload, notifyListeners) {
     articleSlices.set(key, next)
     urlToArticleKey.set(article.url, key)
     if (next.selected) selectedAggregateChanged = true
-    if (notifyListeners) changedArticleKeys.push(key)
+    if (notifyListeners) {
+      changedArticleKeys.push(key)
+      if (
+        Boolean(existing?.removed) !== Boolean(next.removed)
+        || Boolean(existing?.read?.isRead) !== Boolean(next.read?.isRead)
+      ) {
+        dayLifecycleChanged = true
+      }
+    }
   })
 
   const { staleArticleKeys, staleSelectedCount } = deleteStaleArticles(date, nextArticleKeys)
@@ -193,6 +209,7 @@ function ingestPayload(date, payload, notifyListeners) {
   if (notifyListeners) {
     changedArticleKeys.forEach(notifyArticle)
     if (dayArticleSummaryChanged) notifyDayArticleSummary(date)
+    if (dayLifecycleChanged) notifyDayLifecycle(date)
     notifyDay(date)
     if (selectedAggregateChanged || staleSelectedCount > 0) notifyAnySelected()
     staleArticleKeys.forEach(notifyArticle)
@@ -271,6 +288,10 @@ export function applyArticlePatch(key, patch) {
   const date = parseArticleKey(key).date
   const selectedAggregateChanged = current.selected || next.selected
   const dayArticleSummaryChanged = updateDayRemovedCount(date, Boolean(current.removed), Boolean(next.removed))
+  const dayLifecycleChanged = (
+    Boolean(current.removed) !== Boolean(next.removed)
+    || Boolean(current.read?.isRead) !== Boolean(next.read?.isRead)
+  )
 
   if ('selected' in patch) {
     const selectedCountDelta = (patch.selected ? 1 : 0) - (current.selected ? 1 : 0)
@@ -283,12 +304,14 @@ export function applyArticlePatch(key, patch) {
 
   notifyArticle(key)
   if (dayArticleSummaryChanged) notifyDayArticleSummary(date)
+  if (dayLifecycleChanged) notifyDayLifecycle(date)
   if (selectedAggregateChanged) notifyAnySelected()
 }
 
 export function applyArticlePatches(patches) {
   const changedArticleKeys = []
   const changedDaySummaries = new Set()
+  const changedDayLifecycles = new Set()
   let selectedAggregateChanged = false
   let selectedCountDelta = 0
 
@@ -305,6 +328,13 @@ export function applyArticlePatches(patches) {
       changedDaySummaries.add(date)
     }
 
+    if (
+      Boolean(current.removed) !== Boolean(next.removed)
+      || Boolean(current.read?.isRead) !== Boolean(next.read?.isRead)
+    ) {
+      changedDayLifecycles.add(date)
+    }
+
     if (current.selected || next.selected) selectedAggregateChanged = true
 
     if ('selected' in patch) {
@@ -319,6 +349,7 @@ export function applyArticlePatches(patches) {
 
   changedArticleKeys.forEach(notifyArticle)
   changedDaySummaries.forEach(notifyDayArticleSummary)
+  changedDayLifecycles.forEach(notifyDayLifecycle)
   if (selectedAggregateChanged) notifyAnySelected()
 }
 
@@ -350,16 +381,6 @@ function subscribeArticle(key, listener) {
   }
 }
 
-function subscribeArticles(keys, listener) {
-  if (keys.length === 0) return () => {}
-  const unsubscribers = keys.map((key) => subscribeArticle(key, listener))
-  return () => {
-    unsubscribers.forEach((unsubscribe) => {
-      unsubscribe()
-    })
-  }
-}
-
 function subscribeDay(date, listener) {
   if (!dayListeners.has(date)) dayListeners.set(date, new Set())
   dayListeners.get(date).add(listener)
@@ -379,6 +400,17 @@ function subscribeDayArticleSummary(date, listener) {
     if (!set) return
     set.delete(listener)
     if (set.size === 0) dayArticleSummaryListeners.delete(date)
+  }
+}
+
+function subscribeDayLifecycle(date, listener) {
+  if (!dayLifecycleListeners.has(date)) dayLifecycleListeners.set(date, new Set())
+  dayLifecycleListeners.get(date).add(listener)
+  return () => {
+    const set = dayLifecycleListeners.get(date)
+    if (!set) return
+    set.delete(listener)
+    if (set.size === 0) dayLifecycleListeners.delete(date)
   }
 }
 
@@ -465,14 +497,28 @@ export function useDayArticlesSummary(date) {
   )
 }
 
+function countCompletedArticles(date, urls) {
+  return urls.reduce((count, url) => {
+    const article = articleSlices.get(articleKey(date, url))
+    return count + (article?.read?.isRead || article?.removed ? 1 : 0)
+  }, 0)
+}
+
+function areAllArticlesRemoved(date, urls) {
+  return urls.length > 0 && urls.every((url) => articleSlices.get(articleKey(date, url))?.removed)
+}
+
 export function useCompletedArticlesCount(date, urls) {
-  const keys = urls.map((url) => articleKey(date, url))
   return useSyncExternalStore(
-    listener => subscribeArticles(keys, listener),
-    () => keys.reduce((count, key) => {
-      const article = articleSlices.get(key)
-      return count + (article?.read?.isRead || article?.removed ? 1 : 0)
-    }, 0)
+    listener => subscribeDayLifecycle(date, listener),
+    () => countCompletedArticles(date, urls)
+  )
+}
+
+export function useAllArticlesRemoved(date, urls) {
+  return useSyncExternalStore(
+    listener => subscribeDayLifecycle(date, listener),
+    () => areAllArticlesRemoved(date, urls)
   )
 }
 

--- a/client/src/store/articleStore.js
+++ b/client/src/store/articleStore.js
@@ -209,6 +209,10 @@ function ingestPayload(date, payload, notifyListeners) {
   if (notifyListeners) {
     changedArticleKeys.forEach(notifyArticle)
     if (dayArticleSummaryChanged) notifyDayArticleSummary(date)
+
+    /* TODO (Verify): If I understand the flow correctly, when `ingestPayload` removes stale URLs via `deleteStaleArticles`, it only calls `notifyArticle` for those keys, but `useCompletedArticlesCount`/`useAllArticlesRemoved` now subscribe exclusively through `subscribeDayLifecycle`.
+       In the cache→fresh merge path (`mergeDayFromServer`), dropping an article from a day might therefore change these derived values without emitting a day-lifecycle notification.
+       If my reasoning is right, this could leave the `n/m` badge and all-removed visuals stale until another read/remove toggle happens. */
     if (dayLifecycleChanged) notifyDayLifecycle(date)
     notifyDay(date)
     if (selectedAggregateChanged || staleSelectedCount > 0) notifyAnySelected()

--- a/docs/client/reading-overlays.md
+++ b/docs/client/reading-overlays.md
@@ -1,7 +1,7 @@
 ---
 name: client/reading-overlays
 description: Client architecture for reading overlays including ZenMode and Digest.
-last_updated: 2026-05-05 06:38, 36614cc
+last_updated: 2026-05-05 14:05
 ---
 # Client: Reading Overlays
 
@@ -32,9 +32,11 @@ main()
 │           └── Selectable (long press via interactionActions)
 │               └── FoldableContainer (short press: expand/collapse via interaction layer)
 │                   └── NewsletterDay (Iterated by Issue)
+│                       ├── useAllArticlesRemoved(date, urls) / ReadStatsBadge(date, urls)
 │                       └── Selectable
 │                           └── FoldableContainer
 │                               ├── Section (If newsletter has sections)
+│                               │   ├── useAllArticlesRemoved(date, urls)
 │                               │   └── Selectable
 │                               │       └── FoldableContainer
 │                               │           └── ArticleList

--- a/docs/state-machines/articles-and-summaries.md
+++ b/docs/state-machines/articles-and-summaries.md
@@ -1,7 +1,7 @@
 ---
 name: state-machines/articles-and-summaries
 description: State machines for article lifecycle, summary data, digest, and the Zen lock.
-last_updated: 2026-05-05 12:41, a9479b2
+last_updated: 2026-05-05 14:05
 ---
 # State Machines: Articles and Summaries
 
@@ -92,8 +92,9 @@ UNREAD  →  READ  →  REMOVED
 |---|---|---|
 | `ArticleCard` | `isRead`, `isRemoved` | Visual styling, conditional rendering, disable selection |
 | `ArticleList` | `article.removed` | Sort removed articles to bottom |
-| `ReadStatsBadge` | Live article slices resolved from `(date, url)` via `articleStore` | Completion count (`read` or `removed` / total) |
-| `CalendarDay`, `NewsletterDay` | `articles.every(a => a.removed)` | Auto-fold when all removed |
+| `ReadStatsBadge` | Grouped lifecycle selector `useCompletedArticlesCount(date, urls)` backed by `articleStore` | Completion count (`read` or `removed` / total) |
+| `CalendarDay` | `useDayArticlesSummary(date)` | Day-level auto-fold when all articles for the date are removed |
+| `NewsletterDay`, `Section` | Grouped lifecycle selector `useAllArticlesRemoved(date, urls)` backed by `articleStore` | Newsletter/section dimming and auto-fold when all grouped articles are removed |
 | `useSwipeToRemove` | `isRemoved` | Disable drag when removed |
 | `interactionReducer` | `isDisabled(id)` predicate resolving article slice | Prevent selecting removed articles |
 

--- a/docs/state-machines/feed-and-storage.md
+++ b/docs/state-machines/feed-and-storage.md
@@ -1,7 +1,7 @@
 ---
 name: state-machines/feed-and-storage
 description: State machines for feed loading, scrape form, the client article store, and mutation persistence.
-last_updated: 2026-05-05 06:38, 36614cc
+last_updated: 2026-05-05 14:05
 ---
 # State Machines: Feed and Storage
 
@@ -101,7 +101,7 @@ useFeedLoader (results) → App → Feed → CalendarDay → NewsletterDay → A
 
 Feed results provide structural props for date/newsletter/section grouping. Live article, day, selection, summary, and container state comes from `articleStore` subscriptions.
 
-`CalendarDay` consumes `useDayArticlesSummary(date)` for cached day-level derived state such as all-removed auto-folding.
+`CalendarDay` consumes `useDayArticlesSummary(date)` for cached day-level derived state such as all-removed auto-folding. `ReadStatsBadge`, `NewsletterDay`, and section containers consume grouped lifecycle selectors over `(date, urls)` so read/removed transitions stay reactive without scanning structural props.
 
 ---
 
@@ -151,8 +151,8 @@ Client-side only: starts at 10%, increments 5% every 500ms capped at 90%, jumps 
 | `articleSlices` | Per-article live state keyed by article key. |
 | `daySlices` | Per-date payload metadata, digest state, and ordered article keys. |
 | `urlToArticleKey` | URL lookup for selection and summary commands. |
-| Listener maps | Separate subscriptions for article, day, day-article-summary, container, and select-mode state. |
-| Derived caches | Selected descriptors and day article summaries. |
+| Listener maps | Separate subscriptions for article, day, day-article-summary, day-lifecycle, container, and select-mode state. |
+| Derived caches | Selected descriptors and day article summaries. Grouped lifecycle selectors also derive counts and all-removed state from live article slices. |
 
 #### Ingestion
 
@@ -191,7 +191,7 @@ Ingestion also removes stale articles for the day so derived ordering and select
 
 #### Cross-Component Sync
 
-Store actions notify only the listener sets affected by a mutation: article listeners, day listeners, derived day-summary listeners, container listeners, and select-mode listeners. This replaces whole-payload pub/sub with slice-level invalidation.
+Store actions notify only the listener sets affected by a mutation: article listeners, day listeners, derived day-summary listeners, day-lifecycle listeners, container listeners, and select-mode listeners. This replaces whole-payload pub/sub with slice-level invalidation while still supporting grouped lifecycle UI such as badges and all-removed container state.
 
 ---
 

--- a/docs/state-machines/interaction-and-gestures.md
+++ b/docs/state-machines/interaction-and-gestures.md
@@ -1,7 +1,7 @@
 ---
 name: state-machines/interaction-and-gestures
 description: State machines for selection interaction, container expansion, and swipe gestures.
-last_updated: 2026-05-05 06:38, 36614cc
+last_updated: 2026-05-05 14:05
 ---
 # State Machines: Interaction and Gestures
 
@@ -76,7 +76,7 @@ Single key: `expandedContainers:v1` → JSON array of container IDs.
 
 #### Auto-Collapse
 
-`FoldableContainer` accepts `defaultFolded`. `CalendarDay` and `NewsletterDay` consume `useDayArticlesSummary(date)` / grouped article state to determine when all articles are removed. Passing `defaultFolded={true}` triggers `interactionActions.setExpanded(id, false)` — removing the ID from `expandedContainerIds` and persisting.
+`FoldableContainer` accepts `defaultFolded`. `CalendarDay` uses `useDayArticlesSummary(date)` for day-level all-removed state. `NewsletterDay` and section containers use `useAllArticlesRemoved(date, urls)` for grouped lifecycle state over their specific article URL sets. Passing `defaultFolded={true}` triggers `interactionActions.setExpanded(id, false)` — removing the ID from `expandedContainerIds` and persisting.
 
 ---
 

--- a/thoughts/26-05-05-client-read-model-boundaries/initial-discussion.md
+++ b/thoughts/26-05-05-client-read-model-boundaries/initial-discussion.md
@@ -1,5 +1,7 @@
 ---
-last_updated: 2026-05-05 14:17
+last_updated: 2026-05-05 14:19
+result_of: fix/newsletter-counter-and-container-reactivity
+pertains_to: GOTCHAS.md 2026-05-05 ‘Derived multi-article UI can still go stale after a "store-backed" fix if the subscription shape is wrong’ entry
 ---
 
 Yes — **one** meaningful smell stands out.

--- a/thoughts/26-05-05-client-read-model-boundaries/initial-discussion.md
+++ b/thoughts/26-05-05-client-read-model-boundaries/initial-discussion.md
@@ -1,0 +1,36 @@
+---
+last_updated: 2026-05-05 14:17
+---
+
+Yes — **one** meaningful smell stands out.
+
+The store architecture itself is directionally good. The smell is that the client still has **two competing read models for the same concept of “article state”**:
+
+- a payload-shaped `article` object flowing down the component tree, and
+- the live `articleStore` slice keyed by `(date, url)`.
+
+Both are rich enough that a component can plausibly read `removed`, `read`, `summary`, or even key-ish fields like `issueDate` from the wrong one and still look “correct” in code review. That is the problem. **Authority is not encoded strongly enough in the API surface.**
+
+That is why this bug was easy to “fix” incorrectly. The code had already moved off one bad path, so it *looked* aligned with the architecture. But the architecture still allowed grouped UI to be derived in ad-hoc ways: sometimes from live selectors, sometimes from structural props, sometimes from a subscription shape that only *seemed* equivalent. The system is solid at the **per-article write model**, but weaker at the **grouped read model**.
+
+What makes this feel like a real pattern rather than a one-off is that it rhymes with earlier failures. The `issueDate` bug was also an authority problem: a field looked like it came from upstream data, but its true owner was the day key. The dock staleness noted in the audit is likely the same family too: grouped UI depending on live fields without a first-class grouped selector/invalidation model. Different symptoms, same underlying leak.
+
+So if I had to name the deeper smell precisely, I’d call it this:
+
+> **The transport/render prop shape still exposes mutable state that is supposed to be owned by the live store.**
+
+That makes the architecture rely on developer discipline instead of design constraints.
+
+The healthiest long-term direction is not a rewrite. It is to make the boundary sharper:
+
+Structural props should be just that — structural.  
+Things like title, url, source, section, order, date grouping.
+
+Mutable lifecycle/view state should be impossible, or at least unnatural, to read from props. It should come only from first-class selectors, including **group selectors** for grouped UI such as badges, all-removed state, and selected-summary affordances.
+
+In other words: the real lesson here is not “be more careful with `useSyncExternalStore`.”  
+It is:
+
+**Make the wrong source of truth harder to access.**
+
+That would remove an entire class of gotchas, not just this one.


### PR DESCRIPTION
Previously, the n/m badge and all-removed visuals (dimming/auto-fold) in NewsletterDay and Section components were derived from structural article props, leading to stale UI state during read/remove transitions.

This change migrates those components to live grouped lifecycle selectors from articleStore, backed by a new day-level lifecycle notification path.

- Added `useCompletedArticlesCount` and `useAllArticlesRemoved` selectors to `articleStore.js`.
- Added `notifyDayLifecycle` to trigger reactive updates on any article read/removed transition within a date.
- Updated `NewsletterDay`, `Section`, and `ReadStatsBadge` to use the new hooks.
- Updated `GOTCHAS.md` and architectural docs to reflect the new pattern.