### PR TITLE
feat: add RemovedOrderSlot for grouped removed-article ordering

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-05-05 06:33
+last_updated: 2026-05-05 20:52
 ---
 
 .
@@ -113,6 +113,7 @@ last_updated: 2026-05-05 06:33
 │  │  │  ├── NewsletterDay.jsx
 │  │  │  ├── OverlayContextMenu.jsx
 │  │  │  ├── ReadStatsBadge.jsx
+│  │  │  ├── RemovedOrderSlot.jsx
 │  │  │  ├── ScrapeForm.jsx
 │  │  │  ├── Selectable.jsx
 │  │  │  ├── SelectionActionDock.jsx

--- a/client/src/components/CalendarDay.jsx
+++ b/client/src/components/CalendarDay.jsx
@@ -3,6 +3,7 @@ import { hydrateDay, useDayArticlesSummary } from '../store/articleStore'
 import FoldableContainer from './FoldableContainer'
 import NewsletterDay from './NewsletterDay'
 import ReadStatsBadge from './ReadStatsBadge'
+import RemovedOrderSlot from './RemovedOrderSlot'
 import Selectable from './Selectable'
 
 function formatDateDisplay(dateStr) {
@@ -26,21 +27,30 @@ function CalendarDayTitle({ dateStr, articleUrls }) {
 
 function NewsletterList({ date, issues, articles }) {
   return (
-    <div className="space-y-4">
-      {issues.map(issue => {
+    <div className="flex flex-col gap-4">
+      {issues.map((issue, index) => {
         const newsletterName = issue.category
         const newsletterArticles = articles.filter(a => a.category === newsletterName)
 
         if (newsletterArticles.length === 0) return null
 
         return (
-          <NewsletterDay
+          <RemovedOrderSlot
             key={`${date}-${newsletterName}`}
             date={date}
-            title={newsletterName}
-            issue={issue}
-            articles={newsletterArticles}
-          />
+            urls={newsletterArticles.map((article) => article.url)}
+            originalOrder={index}
+          >
+            {(allRemoved) => (
+              <NewsletterDay
+                date={date}
+                title={newsletterName}
+                issue={issue}
+                articles={newsletterArticles}
+                allRemoved={allRemoved}
+              />
+            )}
+          </RemovedOrderSlot>
         )
       })}
     </div>

--- a/client/src/components/NewsletterDay.jsx
+++ b/client/src/components/NewsletterDay.jsx
@@ -1,7 +1,7 @@
-import { useAllArticlesRemoved } from '../store/articleStore'
 import ArticleList from './ArticleList'
 import FoldableContainer from './FoldableContainer'
 import ReadStatsBadge from './ReadStatsBadge'
+import RemovedOrderSlot from './RemovedOrderSlot'
 import Selectable from './Selectable'
 
 function groupArticlesBySection(articles) {
@@ -43,9 +43,7 @@ function SectionTitle({ displayTitle }) {
   )
 }
 
-function Section({ date, sourceId, newsletterTitle, sectionKey, articles }) {
-  const articleUrls = articles.map((article) => article.url)
-  const allRemoved = useAllArticlesRemoved(date, articleUrls)
+function Section({ date, sourceId, newsletterTitle, sectionKey, articles, allRemoved }) {
   const sectionEmoji = articles[0].sectionEmoji
   const displayTitle = sectionEmoji ? `${sectionEmoji} ${sectionKey}` : sectionKey
   const componentId = `section-${date}-${sourceId}-${sectionKey}`
@@ -57,11 +55,11 @@ function Section({ date, sourceId, newsletterTitle, sectionKey, articles }) {
         key={`${newsletterTitle}-${sectionKey}`}
         id={componentId}
         title={<SectionTitle displayTitle={displayTitle} />}
-        headerClassName={`transition-all duration-300 ${allRemoved ? 'opacity-50' : ''}`}
+        headerClassName="transition-all duration-300"
         defaultFolded={allRemoved}
-        className="mb-3"
+        className={`transition-all duration-300 ${allRemoved ? 'opacity-50' : ''}`}
       >
-        <div className={`mt-2 transition-all duration-300 ${allRemoved ? 'opacity-50' : ''}`}>
+        <div className="mt-2 transition-all duration-300">
           <ArticleList articles={articles} />
         </div>
       </FoldableContainer>
@@ -70,21 +68,33 @@ function Section({ date, sourceId, newsletterTitle, sectionKey, articles }) {
 }
 
 function SectionsList({ date, sourceId, title, sections, sortedSectionKeys }) {
-  return sortedSectionKeys.map(sectionKey => (
-    <Section
-      key={`${title}-${sectionKey}`}
-      date={date}
-      sourceId={sourceId}
-      newsletterTitle={title}
-      sectionKey={sectionKey}
-      articles={sections[sectionKey]}
-    />
-  ))
+  return sortedSectionKeys.map((sectionKey, index) => {
+    const articles = sections[sectionKey]
+
+    return (
+      <RemovedOrderSlot
+        key={`${title}-${sectionKey}`}
+        date={date}
+        urls={articles.map((article) => article.url)}
+        originalOrder={index}
+      >
+        {(allRemoved) => (
+          <Section
+            date={date}
+            sourceId={sourceId}
+            newsletterTitle={title}
+            sectionKey={sectionKey}
+            articles={articles}
+            allRemoved={allRemoved}
+          />
+        )}
+      </RemovedOrderSlot>
+    )
+  })
 }
 
-function NewsletterDay({ date, title, issue, articles }) {
+function NewsletterDay({ date, title, issue, articles, allRemoved }) {
   const articleUrls = articles.map((article) => article.url)
-  const allRemoved = useAllArticlesRemoved(date, articleUrls)
   const hasSections = articles.some(a => a.section)
 
   const sections = hasSections ? groupArticlesBySection(articles) : {}
@@ -97,7 +107,8 @@ function NewsletterDay({ date, title, issue, articles }) {
     <Selectable id={componentId} descendantIds={descendantIds}>
       <FoldableContainer
         id={componentId}
-        headerClassName={`border-b border-slate-100 transition-all duration-300 ${allRemoved ? 'opacity-50' : ''}`}
+        headerClassName="border-b border-slate-100 transition-all duration-300"
+        className={`transition-all duration-300 ${allRemoved ? 'opacity-50' : ''}`}
         title={
           <div className="flex items-center gap-2.5 py-2">
             <h3 className="font-display font-semibold text-[17px] text-slate-900">
@@ -108,7 +119,7 @@ function NewsletterDay({ date, title, issue, articles }) {
         }
         defaultFolded={allRemoved}
       >
-        <div className="space-y-4 mt-3">
+        <div className="mt-3 flex flex-col gap-3">
           <IssueSubtitle issue={issue} allRemoved={allRemoved} />
 
           {hasSections ? (

--- a/client/src/components/RemovedOrderSlot.jsx
+++ b/client/src/components/RemovedOrderSlot.jsx
@@ -1,0 +1,15 @@
+import { motion } from 'framer-motion'
+import { useAllArticlesRemoved } from '../store/articleStore'
+
+function RemovedOrderSlot({ date, urls, originalOrder, children, className = '' }) {
+  const allRemoved = useAllArticlesRemoved(date, urls)
+  const order = allRemoved ? 10_000 + originalOrder : originalOrder
+
+  return (
+    <motion.div layout style={{ order }} className={className}>
+      {children(allRemoved)}
+    </motion.div>
+  )
+}
+
+export default RemovedOrderSlot

--- a/docs/client/interaction-and-selection.md
+++ b/docs/client/interaction-and-selection.md
@@ -1,7 +1,7 @@
 ---
 name: client/interaction-and-selection
 description: Client-side interaction architecture, selection modes, and foldable containers.
-last_updated: 2026-05-05 06:38, 36614cc
+last_updated: 2026-05-05 20:55
 ---
 # Client: Interaction and Selection
 
@@ -42,6 +42,10 @@ Selection behavior is implemented as a **declarative state machine** with a smal
 - **FoldableContainer**
   - On click, calls `interactionActions.containerShortPress(containerId)` to expand/collapse, regardless of selection mode.
   - On mount (when `defaultFolded` is true), calls `interactionActions.setExpanded(id, false)` to push initial collapsed state into the shared `expandedContainerIds` set.
+- **RemovedOrderSlot**
+  - Wraps newsletter and section containers in flex lists.
+  - Subscribes to `useAllArticlesRemoved(date, urls)` once for the grouped URL set and passes the result into the rendered container.
+  - Uses that same live all-removed result to sink removed groups via flex order, keeping group ordering, dimming, and auto-collapse on one store-backed read model.
 
 ---
 

--- a/docs/state-machines/interaction-and-gestures.md
+++ b/docs/state-machines/interaction-and-gestures.md
@@ -1,7 +1,7 @@
 ---
 name: state-machines/interaction-and-gestures
 description: State machines for selection interaction, container expansion, and swipe gestures.
-last_updated: 2026-05-05 18:25, a006dd4
+last_updated: 2026-05-05 20:55
 ---
 # State Machines: Interaction and Gestures
 
@@ -74,9 +74,11 @@ Single key: `expandedContainers:v1` → JSON array of container IDs.
 | `newsletter-{date}-{sourceId}` | `NewsletterDay` | `newsletter-2024-01-15-tldr_tech` |
 | `section-{date}-{sourceId}-{sectionKey}` | `NewsletterDay/Section` | `section-2024-01-15-tldr_tech-Web Dev` |
 
-#### Auto-Collapse
+#### Auto-Collapse And Removed Ordering
 
-`FoldableContainer` accepts `defaultFolded`. `CalendarDay` uses `useDayArticlesSummary(date)` for day-level all-removed state. `NewsletterDay` and section containers use `useAllArticlesRemoved(date, urls)` for grouped lifecycle state over their specific article URL sets. Passing `defaultFolded={true}` triggers `interactionActions.setExpanded(id, false)` — removing the ID from `expandedContainerIds` and persisting.
+`FoldableContainer` accepts `defaultFolded`. `CalendarDay` uses `useDayArticlesSummary(date)` for day-level all-removed state. Newsletter and section containers receive grouped lifecycle state from `RemovedOrderSlot`, which subscribes through `useAllArticlesRemoved(date, urls)` for their specific article URL sets. Passing `defaultFolded={true}` triggers `interactionActions.setExpanded(id, false)` — removing the ID from `expandedContainerIds` and persisting.
+
+`RemovedOrderSlot` also gives all-removed groups a high flex order, so fully removed sections sink within a newsletter and fully removed newsletters sink within their calendar day using the same live grouped read model that drives dimming and auto-collapse.
 
 ---
 


### PR DESCRIPTION
- Added RemovedOrderSlot, a reusable Framer Motion wrapper that
  subscribes to the live grouped useAllArticlesRemoved(date, urls)
  selector, passes that result into its child render function, and
  sinks fully removed groups with a high flex order.

- Wrapped newsletters within each calendar day in RemovedOrderSlot,
  switched the list to flex gap spacing, and passed the grouped
  all-removed state into NewsletterDay so fully removed newsletters
  reposition downward dynamically.

- Reused RemovedOrderSlot for newsletter sections, so fully removed
  sections sink within TLDR-style newsletters while sharing the same
  all-removed value for auto-collapse and dimming.

- Made section and newsletter containers dim from the grouped
  all-removed state and continue using that same state for
  defaultFolded.

- Documented the new grouped ordering/read-model responsibility in
  the client interaction docs and state-machine docs.

- Updated the generated project structure to include the new
  component.
