### PR TITLE
Sink removed newsletter groups with store-backed ordering and dimming

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-05-05 06:33
+last_updated: 2026-05-05 20:20
 ---
 
 .
@@ -7,7 +7,6 @@ last_updated: 2026-05-05 06:33
 │  └── skills
 │     ├── architecture-create
 │     │  └── SKILL.md
-│     ├── architecture-sync-since-last-updated
 │     ├── consensus
 │     │  ├── scripts
 │     │  │  └── run_consensus.py
@@ -36,7 +35,6 @@ last_updated: 2026-05-05 06:33
 │     │  └── SKILL.md
 │     ├── research-codebase
 │     │  └── SKILL.md
-│     ├── review-plan
 │     ├── simplify-code
 │     │  └── SKILL.md
 │     ├── supabase-postgres-best-practices
@@ -49,9 +47,6 @@ last_updated: 2026-05-05 06:33
 │     │  └── SKILL.md
 │     └── web-a11y-guidelines
 │        └── SKILL.md
-├── .fallow
-│  ├── .gitignore
-│  └── churn.bin
 ├── .githooks
 │  ├── post-merge
 │  ├── pre-commit
@@ -113,6 +108,7 @@ last_updated: 2026-05-05 06:33
 │  │  │  ├── NewsletterDay.jsx
 │  │  │  ├── OverlayContextMenu.jsx
 │  │  │  ├── ReadStatsBadge.jsx
+│  │  │  ├── RemovedOrderSlot.jsx
 │  │  │  ├── ScrapeForm.jsx
 │  │  │  ├── Selectable.jsx
 │  │  │  ├── SelectionActionDock.jsx
@@ -171,7 +167,6 @@ last_updated: 2026-05-05 06:33
 │  ├── create_digests_table.sql
 │  ├── create_patch_daily_article_function.sql
 │  └── create_patch_daily_payload_function.sql
-├── hidden_apps
 ├── scripts
 │  ├── dev
 │  │  ├── auto-pr-merge.sh
@@ -211,7 +206,6 @@ last_updated: 2026-05-05 06:33
 ├── .gitattributes
 ├── .gitignore
 ├── .gitmodules
-├── .synthesize-findings.md
 ├── .vercelignore
 ├── AGENTS.md
 ├── BUGS.md

--- a/client/src/components/CalendarDay.jsx
+++ b/client/src/components/CalendarDay.jsx
@@ -3,6 +3,7 @@ import { hydrateDay, useDayArticlesSummary } from '../store/articleStore'
 import FoldableContainer from './FoldableContainer'
 import NewsletterDay from './NewsletterDay'
 import ReadStatsBadge from './ReadStatsBadge'
+import RemovedOrderSlot from './RemovedOrderSlot'
 import Selectable from './Selectable'
 
 function formatDateDisplay(dateStr) {
@@ -26,21 +27,30 @@ function CalendarDayTitle({ dateStr, articleUrls }) {
 
 function NewsletterList({ date, issues, articles }) {
   return (
-    <div className="space-y-4">
-      {issues.map(issue => {
+    <div className="flex flex-col gap-4">
+      {issues.map((issue, index) => {
         const newsletterName = issue.category
         const newsletterArticles = articles.filter(a => a.category === newsletterName)
 
         if (newsletterArticles.length === 0) return null
 
         return (
-          <NewsletterDay
+          <RemovedOrderSlot
             key={`${date}-${newsletterName}`}
             date={date}
-            title={newsletterName}
-            issue={issue}
-            articles={newsletterArticles}
-          />
+            urls={newsletterArticles.map((article) => article.url)}
+            originalOrder={index}
+          >
+            {(allRemoved) => (
+              <NewsletterDay
+                date={date}
+                title={newsletterName}
+                issue={issue}
+                articles={newsletterArticles}
+                allRemoved={allRemoved}
+              />
+            )}
+          </RemovedOrderSlot>
         )
       })}
     </div>

--- a/client/src/components/NewsletterDay.jsx
+++ b/client/src/components/NewsletterDay.jsx
@@ -1,7 +1,7 @@
-import { useAllArticlesRemoved } from '../store/articleStore'
 import ArticleList from './ArticleList'
 import FoldableContainer from './FoldableContainer'
 import ReadStatsBadge from './ReadStatsBadge'
+import RemovedOrderSlot from './RemovedOrderSlot'
 import Selectable from './Selectable'
 
 function groupArticlesBySection(articles) {
@@ -43,9 +43,7 @@ function SectionTitle({ displayTitle }) {
   )
 }
 
-function Section({ date, sourceId, newsletterTitle, sectionKey, articles }) {
-  const articleUrls = articles.map((article) => article.url)
-  const allRemoved = useAllArticlesRemoved(date, articleUrls)
+function Section({ date, sourceId, newsletterTitle, sectionKey, articles, allRemoved }) {
   const sectionEmoji = articles[0].sectionEmoji
   const displayTitle = sectionEmoji ? `${sectionEmoji} ${sectionKey}` : sectionKey
   const componentId = `section-${date}-${sourceId}-${sectionKey}`
@@ -57,11 +55,11 @@ function Section({ date, sourceId, newsletterTitle, sectionKey, articles }) {
         key={`${newsletterTitle}-${sectionKey}`}
         id={componentId}
         title={<SectionTitle displayTitle={displayTitle} />}
-        headerClassName={`transition-all duration-300 ${allRemoved ? 'opacity-50' : ''}`}
+        headerClassName="transition-all duration-300"
         defaultFolded={allRemoved}
-        className="mb-3"
+        className={`transition-all duration-300 ${allRemoved ? 'opacity-50' : ''}`}
       >
-        <div className={`mt-2 transition-all duration-300 ${allRemoved ? 'opacity-50' : ''}`}>
+        <div className="mt-2 transition-all duration-300">
           <ArticleList articles={articles} />
         </div>
       </FoldableContainer>
@@ -70,21 +68,33 @@ function Section({ date, sourceId, newsletterTitle, sectionKey, articles }) {
 }
 
 function SectionsList({ date, sourceId, title, sections, sortedSectionKeys }) {
-  return sortedSectionKeys.map(sectionKey => (
-    <Section
-      key={`${title}-${sectionKey}`}
-      date={date}
-      sourceId={sourceId}
-      newsletterTitle={title}
-      sectionKey={sectionKey}
-      articles={sections[sectionKey]}
-    />
-  ))
+  return sortedSectionKeys.map((sectionKey, index) => {
+    const articles = sections[sectionKey]
+
+    return (
+      <RemovedOrderSlot
+        key={`${title}-${sectionKey}`}
+        date={date}
+        urls={articles.map((article) => article.url)}
+        originalOrder={index}
+      >
+        {(allRemoved) => (
+          <Section
+            date={date}
+            sourceId={sourceId}
+            newsletterTitle={title}
+            sectionKey={sectionKey}
+            articles={articles}
+            allRemoved={allRemoved}
+          />
+        )}
+      </RemovedOrderSlot>
+    )
+  })
 }
 
-function NewsletterDay({ date, title, issue, articles }) {
+function NewsletterDay({ date, title, issue, articles, allRemoved }) {
   const articleUrls = articles.map((article) => article.url)
-  const allRemoved = useAllArticlesRemoved(date, articleUrls)
   const hasSections = articles.some(a => a.section)
 
   const sections = hasSections ? groupArticlesBySection(articles) : {}
@@ -97,7 +107,8 @@ function NewsletterDay({ date, title, issue, articles }) {
     <Selectable id={componentId} descendantIds={descendantIds}>
       <FoldableContainer
         id={componentId}
-        headerClassName={`border-b border-slate-100 transition-all duration-300 ${allRemoved ? 'opacity-50' : ''}`}
+        headerClassName="border-b border-slate-100 transition-all duration-300"
+        className={`transition-all duration-300 ${allRemoved ? 'opacity-50' : ''}`}
         title={
           <div className="flex items-center gap-2.5 py-2">
             <h3 className="font-display font-semibold text-[17px] text-slate-900">
@@ -108,7 +119,7 @@ function NewsletterDay({ date, title, issue, articles }) {
         }
         defaultFolded={allRemoved}
       >
-        <div className="space-y-4 mt-3">
+        <div className="mt-3 flex flex-col gap-3">
           <IssueSubtitle issue={issue} allRemoved={allRemoved} />
 
           {hasSections ? (

--- a/client/src/components/RemovedOrderSlot.jsx
+++ b/client/src/components/RemovedOrderSlot.jsx
@@ -1,0 +1,15 @@
+import { motion } from 'framer-motion'
+import { useAllArticlesRemoved } from '../store/articleStore'
+
+function RemovedOrderSlot({ date, urls, originalOrder, children, className = '' }) {
+  const allRemoved = useAllArticlesRemoved(date, urls)
+  const order = allRemoved ? 10_000 + originalOrder : originalOrder
+
+  return (
+    <motion.div layout style={{ order }} className={className}>
+      {children(allRemoved)}
+    </motion.div>
+  )
+}
+
+export default RemovedOrderSlot

--- a/docs/client/interaction-and-selection.md
+++ b/docs/client/interaction-and-selection.md
@@ -1,7 +1,7 @@
 ---
 name: client/interaction-and-selection
 description: Client-side interaction architecture, selection modes, and foldable containers.
-last_updated: 2026-05-05 06:38, 36614cc
+last_updated: 2026-05-05 20:20
 ---
 # Client: Interaction and Selection
 
@@ -42,6 +42,10 @@ Selection behavior is implemented as a **declarative state machine** with a smal
 - **FoldableContainer**
   - On click, calls `interactionActions.containerShortPress(containerId)` to expand/collapse, regardless of selection mode.
   - On mount (when `defaultFolded` is true), calls `interactionActions.setExpanded(id, false)` to push initial collapsed state into the shared `expandedContainerIds` set.
+- **RemovedOrderSlot**
+  - Wraps newsletter and section containers in flex lists.
+  - Subscribes to `useAllArticlesRemoved(date, urls)` once for the grouped URL set and passes the result into the rendered container.
+  - Uses that same live all-removed result to sink removed groups via flex order, keeping group ordering, dimming, and auto-collapse on one store-backed read model.
 
 ---
 

--- a/docs/state-machines/interaction-and-gestures.md
+++ b/docs/state-machines/interaction-and-gestures.md
@@ -1,7 +1,7 @@
 ---
 name: state-machines/interaction-and-gestures
 description: State machines for selection interaction, container expansion, and swipe gestures.
-last_updated: 2026-05-05 18:25, a006dd4
+last_updated: 2026-05-05 20:20
 ---
 # State Machines: Interaction and Gestures
 
@@ -74,9 +74,11 @@ Single key: `expandedContainers:v1` → JSON array of container IDs.
 | `newsletter-{date}-{sourceId}` | `NewsletterDay` | `newsletter-2024-01-15-tldr_tech` |
 | `section-{date}-{sourceId}-{sectionKey}` | `NewsletterDay/Section` | `section-2024-01-15-tldr_tech-Web Dev` |
 
-#### Auto-Collapse
+#### Auto-Collapse And Removed Ordering
 
-`FoldableContainer` accepts `defaultFolded`. `CalendarDay` uses `useDayArticlesSummary(date)` for day-level all-removed state. `NewsletterDay` and section containers use `useAllArticlesRemoved(date, urls)` for grouped lifecycle state over their specific article URL sets. Passing `defaultFolded={true}` triggers `interactionActions.setExpanded(id, false)` — removing the ID from `expandedContainerIds` and persisting.
+`FoldableContainer` accepts `defaultFolded`. `CalendarDay` uses `useDayArticlesSummary(date)` for day-level all-removed state. Newsletter and section containers receive grouped lifecycle state from `RemovedOrderSlot`, which subscribes through `useAllArticlesRemoved(date, urls)` for their specific article URL sets. Passing `defaultFolded={true}` triggers `interactionActions.setExpanded(id, false)` — removing the ID from `expandedContainerIds` and persisting.
+
+`RemovedOrderSlot` also gives all-removed groups a high flex order, so fully removed sections sink within a newsletter and fully removed newsletters sink within their calendar day using the same live grouped read model that drives dimming and auto-collapse.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Make newsletter sections and whole newsletters reposition downward when all their articles are removed (same UX as article cards) and ensure newsletters dim when empty. 
- Reuse the existing live grouped read model (`useAllArticlesRemoved`) rather than introducing ad-hoc props or duplicated subscriptions. 
- Keep the change surgical and composable so it plugs into the existing `FoldableContainer` / `interactionActions` behavior and respects `defaultFolded`. 
- Follow the guidance in `thoughts/26-05-05-client-read-model-boundaries/initial-discussion.md` to avoid adding a second read model for grouped lifecycle state.

### Description
- Added a small reusable wrapper component `RemovedOrderSlot` (`client/src/components/RemovedOrderSlot.jsx`) that subscribes to the grouped selector `useAllArticlesRemoved(date, urls)`, computes a high flex `order` when the group is fully removed, and exposes the `allRemoved` boolean to its child via a render prop. 
- Wrapped newsletters in `CalendarDay` and sections in `NewsletterDay` with `RemovedOrderSlot` so fully-removed groups sink via the same `order` technique and animate with Framer Motion `layout`. 
- Passed the grouped `allRemoved` result into `NewsletterDay` / section rendering so dimming and `defaultFolded` continue to be driven from the single store-backed selector (no new read model). 
- Small layout adjustments: newsletter lists changed to flex column + gap spacing to support ordering; section/newsletter container classes now apply dimming via the passed `allRemoved`. 
- Documentation updated to reflect the new wrapper and read-model choice in `docs/client/interaction-and-selection.md` and `docs/state-machines/interaction-and-gestures.md`.

### Testing
- Ran `./setup.sh`; it executed but reported missing helper scripts previously during environment sync (informational). 
- Ran `npm install` in the `client/` directory and it completed successfully. 
- Built the client with `npm run build` and the build completed successfully. 
- Ran the client linter `npm run lint`; it exited 0, but the code-quality report still lists pre-existing findings (dead-code / duplication / health notes) unrelated to this change. 
- Ran `git diff --check` (format/whitespace checks) with no blocking issues. 
- Attempted a Playwright screenshot to visually verify ordering, but the environment could not launch Chromium due to missing system library `libatk-1.0.so.0`; this is an environment limitation, not a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa50131cd4833293c144d7c11a2122)