### PR TITLE
feat: overlay link menu — Open and Summarize actions

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-05-12 21:38
+last_updated: 2026-05-13 20:18
 ---
 
 .
@@ -58,6 +58,7 @@ last_updated: 2026-05-12 21:38
 │  │  │  ├── ElaborationPreview.jsx
 │  │  │  ├── Feed.jsx
 │  │  │  ├── FoldableContainer.jsx
+│  │  │  ├── LinkSummarizePreview.jsx
 │  │  │  ├── NewsletterDay.jsx
 │  │  │  ├── OverlayContextMenu.jsx
 │  │  │  ├── OverlayLink.jsx
@@ -76,6 +77,7 @@ last_updated: 2026-05-12 21:38
 │  │  │  ├── useDigest.js
 │  │  │  ├── useElaboration.js
 │  │  │  ├── useFeedLoader.js
+│  │  │  ├── useLinkSummarize.js
 │  │  │  ├── useLongPress.js
 │  │  │  ├── useOverlayContextMenu.js
 │  │  │  ├── useOverscrollUp.js

--- a/client/src/components/BaseOverlay.jsx
+++ b/client/src/components/BaseOverlay.jsx
@@ -1,10 +1,12 @@
 import { FloatingNode, useDismiss, useFloating, useFloatingNodeId, useInteractions } from '@floating-ui/react'
-import { Check, CheckCircle, ChevronDown, Link as LinkIcon } from 'lucide-react'
+import { AlignLeft, Check, CheckCircle, ChevronDown, ExternalLink } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { useLinkSummarize } from '../hooks/useLinkSummarize'
 import { useOverscrollUp } from '../hooks/useOverscrollUp'
 import { usePullToClose } from '../hooks/usePullToClose'
 import { useScrollProgress } from '../hooks/useScrollProgress'
+import LinkSummarizePreview from './LinkSummarizePreview'
 import OverlayContextMenu from './OverlayContextMenu'
 import { OverlayLinkMenuContext } from './OverlayLinkMenuContext'
 
@@ -57,14 +59,22 @@ function BaseOverlay({
     openOverlayLinkMenu,
   }), [openOverlayLinkMenu])
 
+  const { linkSummary, runLinkSummarize, closeLinkSummary } = useLinkSummarize()
+
   const linkMenuActions = useMemo(() => ([
     {
-      key: 'dummy-link-action',
-      label: 'Dummy action',
-      icon: <LinkIcon size={15} />,
-      onSelect: () => console.log('[overlay-link] dummy action — url:', linkMenuState.href),
+      key: 'open-tab',
+      label: 'Open',
+      icon: <ExternalLink size={15} />,
+      onSelect: (href) => window.open(href, '_blank', 'noopener,noreferrer'),
     },
-  ]), [linkMenuState.href])
+    {
+      key: 'summarize-link',
+      label: 'Summarize',
+      icon: <AlignLeft size={15} />,
+      onSelect: runLinkSummarize,
+    },
+  ]), [runLinkSummarize])
 
   const { progress, hasScrolled } = useScrollProgress(scrollRef)
   // usePullToClose attaches a non-passive touchmove listener that calls preventDefault() on every
@@ -217,6 +227,15 @@ function BaseOverlay({
         )}
 
         {overlayLayers}
+
+        <LinkSummarizePreview
+          isOpen={linkSummary.status !== 'idle'}
+          status={linkSummary.status}
+          url={linkSummary.url}
+          markdown={linkSummary.markdown}
+          errorMessage={linkSummary.errorMessage}
+          onClose={closeLinkSummary}
+        />
       </FloatingNode>
     </OverlayLinkMenuContext.Provider>
   )

--- a/client/src/components/LinkSummarizePreview.jsx
+++ b/client/src/components/LinkSummarizePreview.jsx
@@ -1,0 +1,147 @@
+import {
+  FloatingFocusManager,
+  FloatingNode,
+  FloatingPortal,
+  useDismiss,
+  useFloating,
+  useFloatingNodeId,
+  useInteractions,
+} from '@floating-ui/react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { AlignLeft, X } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { markdownToHtml } from '../lib/markdownUtils'
+import { overlayProseClassName } from './BaseOverlay'
+
+function UrlEcho({ url }) {
+  if (!url) return null
+  const truncated = url.length > 80 ? `${url.slice(0, 80)}…` : url
+  return (
+    <p className="text-xs font-mono text-slate-500 leading-snug line-clamp-1 break-all">
+      {truncated}
+    </p>
+  )
+}
+
+function LoadingBody({ url }) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 text-center">
+      <motion.div
+        animate={{ scale: [1, 1.08, 1], opacity: [0.7, 1, 0.7] }}
+        transition={{ duration: 1.6, repeat: Infinity, ease: 'easeInOut' }}
+        className="flex h-12 w-12 items-center justify-center rounded-full bg-brand-50 text-brand-500"
+      >
+        <AlignLeft size={22} />
+      </motion.div>
+      <p className="text-sm font-medium text-slate-500">Summarizing…</p>
+      <div className="max-w-sm">
+        <UrlEcho url={url} />
+      </div>
+    </div>
+  )
+}
+
+function ErrorBody({ message }) {
+  return (
+    <div className="flex flex-1 items-center justify-center px-6">
+      <p className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-600">
+        {message || 'Summarization failed. Try again.'}
+      </p>
+    </div>
+  )
+}
+
+function AvailableBody({ markdown, url }) {
+  const html = useMemo(() => markdownToHtml(markdown), [markdown])
+  return (
+    <>
+      <div className="shrink-0 border-b border-slate-200/60 px-5 py-3">
+        <UrlEcho url={url} />
+      </div>
+      <div className="flex-1 overflow-y-auto px-5 py-4">
+        <div className={overlayProseClassName} dangerouslySetInnerHTML={{ __html: html }} />
+      </div>
+    </>
+  )
+}
+
+function LinkSummarizePreview({ isOpen, status, url, markdown, errorMessage, onClose }) {
+  const [isMounted, setIsMounted] = useState(isOpen)
+  const closeButtonRef = useRef(null)
+  const nodeId = useFloatingNodeId()
+
+  useEffect(() => {
+    if (isOpen) setIsMounted(true)
+  }, [isOpen])
+
+  const { refs, context } = useFloating({
+    nodeId,
+    open: isMounted,
+    onOpenChange: (open) => {
+      if (!open) onClose()
+    },
+  })
+  const dismiss = useDismiss(context, { escapeKey: true, outsidePress: true })
+  const { getFloatingProps } = useInteractions([dismiss])
+
+  if (!isMounted) return null
+
+  return (
+    <FloatingNode id={nodeId}>
+      <FloatingPortal>
+        <AnimatePresence onExitComplete={() => setIsMounted(false)}>
+          {isOpen && (
+            <motion.div
+              className="fixed inset-0 z-[210] flex items-center justify-center"
+              onClick={(event) => event.stopPropagation()}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.18 }}
+            >
+              <div className="absolute inset-0 bg-slate-900/30 backdrop-blur-sm" />
+              <FloatingFocusManager
+                context={context}
+                modal={true}
+                returnFocus={true}
+                initialFocus={closeButtonRef}
+              >
+                <motion.div
+                  {...getFloatingProps({
+                    ref: refs.setFloating,
+                    role: 'dialog',
+                    'aria-modal': true,
+                    'aria-label': 'Link Summary',
+                    initial: { opacity: 0, scale: 0.92 },
+                    animate: { opacity: 1, scale: 1 },
+                    exit: { opacity: 0, scale: 0.96 },
+                    transition: { type: 'spring', stiffness: 320, damping: 28 },
+                    className: 'relative flex h-[60vh] w-[85vw] max-w-xl flex-col overflow-hidden rounded-3xl border border-white/60 bg-white/80 shadow-elevated backdrop-blur-2xl',
+                  })}
+                >
+                  <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/80 to-transparent" />
+
+                  <button
+                    ref={closeButtonRef}
+                    type="button"
+                    onClick={onClose}
+                    aria-label="Close"
+                    className="absolute right-3 top-3 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-white/70 text-slate-500 shadow-card backdrop-blur transition-colors hover:bg-white hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-400/60"
+                  >
+                    <X size={15} />
+                  </button>
+
+                  {status === 'loading' && <LoadingBody url={url} />}
+                  {status === 'error' && <ErrorBody message={errorMessage} />}
+                  {status === 'available' && <AvailableBody markdown={markdown} url={url} />}
+                </motion.div>
+              </FloatingFocusManager>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </FloatingPortal>
+    </FloatingNode>
+  )
+}
+
+export default LinkSummarizePreview

--- a/client/src/hooks/useLinkSummarize.js
+++ b/client/src/hooks/useLinkSummarize.js
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const IDLE_LINK_SUMMARY = Object.freeze({
+  status: 'idle',
+  url: '',
+  markdown: '',
+  errorMessage: '',
+})
+
+export function useLinkSummarize() {
+  const [linkSummary, setLinkSummary] = useState(IDLE_LINK_SUMMARY)
+  const abortControllerRef = useRef(null)
+
+  useEffect(() => {
+    return () => abortControllerRef.current?.abort()
+  }, [])
+
+  const closeLinkSummary = useCallback(() => {
+    abortControllerRef.current?.abort()
+    abortControllerRef.current = null
+    setLinkSummary(IDLE_LINK_SUMMARY)
+  }, [])
+
+  const runLinkSummarize = useCallback(async (url) => {
+    if (!url) return
+
+    abortControllerRef.current?.abort()
+    const controller = new AbortController()
+    abortControllerRef.current = controller
+
+    console.log('[link-summarize] starting — url:', url.slice(0, 80))
+    setLinkSummary({ status: 'loading', url, markdown: '', errorMessage: '' })
+
+    try {
+      const response = await window.fetch('/api/summarize-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url }),
+        signal: controller.signal,
+      })
+      const result = await response.json()
+      if (controller.signal.aborted) {
+        console.log('[link-summarize] aborted after response — discarding')
+        return
+      }
+
+      if (!response.ok || !result.success) {
+        console.log('[link-summarize] error response —', result.error)
+        setLinkSummary({ status: 'error', url, markdown: '', errorMessage: result.error || 'Failed to summarize.' })
+        return
+      }
+
+      console.log('[link-summarize] success — markdown length:', result.summary_markdown?.length)
+      setLinkSummary({ status: 'available', url, markdown: result.summary_markdown, errorMessage: '' })
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        console.log('[link-summarize] fetch aborted')
+        return
+      }
+      console.log('[link-summarize] fetch error —', error.message)
+      setLinkSummary({ status: 'error', url, markdown: '', errorMessage: error.message || 'Failed to summarize.' })
+    }
+  }, [])
+
+  return { linkSummary, runLinkSummarize, closeLinkSummary }
+}


### PR DESCRIPTION
## Summary

- Replaces the dummy `linkMenuActions` in `BaseOverlay` with two real actions triggered by long-pressing (or right-clicking) any `OverlayLink`
- **Open**: opens the link URL in a new tab via `window.open`
- **Summarize**: calls `POST /api/summarize-url` and displays the result in a transient `LinkSummarizePreview` modal — same animated entry/exit, backdrop, and dismiss behaviour as `ElaborationPreview`

`BaseOverlay` owns both the link menu state and the new `useLinkSummarize` hook since it already manages the link menu. The `LinkSummarizePreview` is rendered as a sibling to `overlayLayers`, inside the same `FloatingNode`.

## New files

- `client/src/hooks/useLinkSummarize.js` — hook modelled after `useElaboration` (AbortController, idle/loading/available/error states, calls `/api/summarize-url`)
- `client/src/components/LinkSummarizePreview.jsx` — transient modal modelled after `ElaborationPreview` (framer-motion animate/exit, `FloatingFocusManager`, URL echo strip)

## Test plan

- [ ] Long-press (or right-click) a link inside any overlay (ZenMode or Digest)
- [ ] Verify menu shows "Open" and "Summarize" (no more "Dummy action")
- [ ] "Open" → new tab opens at the link URL
- [ ] "Summarize" → loading spinner appears, then summary markdown renders in the modal
- [ ] Escape key and outside-click dismiss the summary modal
- [ ] Opening the link menu while a summary is already shown does not break either

🤖 Generated with [Claude Code](https://claude.com/claude-code)