### PR TITLE
feat(client): Add 'Add Article' UI with clipboard URL prefill

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,5 @@
 import { FloatingTree } from '@floating-ui/react'
-import { Bug, Calendar } from 'lucide-react'
+import { Bug, Calendar, Link, Plus } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import DebugPanel from './components/DebugPanel'
 import DigestOverlay from './components/DigestOverlay'
@@ -15,6 +15,7 @@ import { ArticleLifecycleEventType, reduceArticleLifecycle } from './reducers/ar
 import * as summaryDataReducer from './reducers/summaryDataReducer'
 import {
   getSnapshotArticle,
+  ingestDayPayload,
   interactionActions,
   summaryActions,
   useFeedStatus,
@@ -26,6 +27,21 @@ import {
 function toBrowserUrl(url) {
   if (url.startsWith('http://') || url.startsWith('https://')) return url
   return `https://${url}`
+}
+
+function canonicalizeCandidateUrl(urlText) {
+  const trimmedUrl = urlText.trim()
+  if (!trimmedUrl) return ''
+  const urlWithScheme = trimmedUrl.includes('://') ? trimmedUrl : `https://${trimmedUrl}`
+  try {
+    const parsed = new URL(urlWithScheme)
+    const normalizedHost = parsed.hostname.toLowerCase().replace(/^www\./, '')
+    if (!normalizedHost.includes('.')) return ''
+    const normalizedPath = parsed.pathname === '/' ? '' : parsed.pathname
+    return `${normalizedHost}${normalizedPath}`
+  } catch {
+    return ''
+  }
 }
 
 async function applyBatchLifecyclePatch(selectedArticles, eventFactory) {
@@ -42,6 +58,10 @@ function AppContent({ loadFeed, showSettings, setShowSettings, showDebug, setSho
   const digest = useDigest()
   const [isPodcastLoading, setIsPodcastLoading] = useState(false)
   const [podcastAudioUrl, setPodcastAudioUrl] = useState(null)
+  const [isAddArticleOpen, setIsAddArticleOpen] = useState(false)
+  const [addArticleUrlInput, setAddArticleUrlInput] = useState('')
+  const [isAddArticleSubmitting, setIsAddArticleSubmitting] = useState(false)
+  const [isClipboardPrefill, setIsClipboardPrefill] = useState(false)
   const isSelectMode = useIsSelectMode()
   const selectedArticles = useSelectedArticles()
   const selectedCount = selectedArticles.length
@@ -63,6 +83,24 @@ function AppContent({ loadFeed, showSettings, setShowSettings, showDebug, setSho
     return status === summaryDataReducer.SummaryDataStatus.UNKNOWN || status === summaryDataReducer.SummaryDataStatus.ERROR
   }).length
   const isSummarizeEachDisabled = selectedCount < 2 || summarizeEachActionableCount === 0
+  const canonicalCandidateUrl = canonicalizeCandidateUrl(addArticleUrlInput)
+  const canSubmitArticleUrl = canonicalCandidateUrl.length > 0
+
+  useEffect(() => {
+    if (!isAddArticleOpen) return
+    if (!navigator.clipboard?.readText) return
+    navigator.clipboard.readText()
+      .then((clipboardText) => {
+        const trimmedClipboardText = clipboardText.trim()
+        const hasUrlInClipboard = canonicalizeCandidateUrl(trimmedClipboardText).length > 0
+        if (!hasUrlInClipboard) return
+        setAddArticleUrlInput(trimmedClipboardText)
+        setIsClipboardPrefill(true)
+      })
+      .catch((error) => {
+        console.debug('Clipboard prefill unavailable:', error)
+      })
+  }, [isAddArticleOpen])
 
   function handleTriggerDigest() {
     digest.trigger(selectedArticles)
@@ -86,6 +124,41 @@ function AppContent({ loadFeed, showSettings, setShowSettings, showDebug, setSho
     } finally {
       setIsPodcastLoading(false)
     }
+  }
+
+  async function submitAddArticleUrl(urlText) {
+    if (!canonicalizeCandidateUrl(urlText)) return
+    if (isAddArticleSubmitting) return
+    setIsAddArticleSubmitting(true)
+    try {
+      const response = await window.fetch('/api/url-to-article', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: urlText.trim() }),
+      })
+      const result = await response.json()
+      if (!response.ok || !result.success) {
+        throw new Error(result.error || `Add article request failed with ${response.status}`)
+      }
+      if (result.payload) ingestDayPayload(result.payload)
+      setAddArticleUrlInput('')
+      setIsClipboardPrefill(false)
+      setIsAddArticleOpen(false)
+    } catch (error) {
+      console.error('Failed to add article URL:', error)
+    } finally {
+      setIsAddArticleSubmitting(false)
+    }
+  }
+
+  function handleAddArticleInputChange(event) {
+    const nextInputValue = event.target.value
+    setAddArticleUrlInput(nextInputValue)
+    if (isClipboardPrefill) {
+      setIsClipboardPrefill(false)
+      return
+    }
+    submitAddArticleUrl(nextInputValue)
   }
 
   useEffect(() => {
@@ -160,6 +233,13 @@ function AppContent({ loadFeed, showSettings, setShowSettings, showDebug, setSho
 
             <div className="flex items-center gap-3">
               <button
+                onClick={() => setIsAddArticleOpen(value => !value)}
+                className={`group flex items-center justify-center w-10 h-10 rounded-full transition-all duration-300 ${isAddArticleOpen ? 'bg-cyan-50 text-cyan-600' : 'hover:bg-white hover:shadow-md text-slate-400'}`}
+                title="Add Article"
+              >
+                <Link size={18} className="transition-colors" />
+              </button>
+              <button
                 onClick={() => setShowDebug(!showDebug)}
                 className={`group flex items-center justify-center w-10 h-10 rounded-full transition-all duration-300 ${showDebug ? 'bg-emerald-50 text-emerald-600' : 'hover:bg-white hover:shadow-md text-slate-400'}`}
                 title="Debug Panel"
@@ -172,6 +252,30 @@ function AppContent({ loadFeed, showSettings, setShowSettings, showDebug, setSho
                 title="Date Range & Settings"
               >
                 <Calendar size={18} className="transition-colors" />
+              </button>
+            </div>
+          </div>
+
+          <div className={`
+              overflow-hidden transition-all duration-300 ease-in-out
+              ${isAddArticleOpen ? 'max-h-[180px] opacity-100 mt-4' : 'max-h-0 opacity-0'}
+          `}>
+            <div className="bg-white rounded-2xl p-4 shadow-elevated border border-slate-200/50 flex flex-col gap-3">
+              <input
+                type="text"
+                value={addArticleUrlInput}
+                onChange={handleAddArticleInputChange}
+                placeholder="Paste or type article URL"
+                className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-300"
+              />
+              <button
+                type="button"
+                onClick={() => submitAddArticleUrl(addArticleUrlInput)}
+                disabled={!canSubmitArticleUrl || isAddArticleSubmitting || !isClipboardPrefill}
+                className="inline-flex items-center justify-center gap-2 self-end rounded-xl bg-brand-600 px-3 py-2 text-sm font-semibold text-white disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <Plus size={14} />
+                {isAddArticleSubmitting ? 'Adding…' : 'Add'}
               </button>
             </div>
           </div>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,6 +10,7 @@ import SelectionActionDock from './components/SelectionActionDock'
 import ToastContainer from './components/ToastContainer'
 import { useDigest } from './hooks/useDigest'
 import { getDefaultFeedDateRange, useFeedLoader } from './hooks/useFeedLoader'
+import { readApiResponse } from './lib/apiError'
 import { queueBatchArticlePatches } from './lib/dailyPayloadMutations'
 import { ArticleLifecycleEventType, reduceArticleLifecycle } from './reducers/articleLifecycleReducer'
 import * as summaryDataReducer from './reducers/summaryDataReducer'
@@ -136,10 +137,8 @@ function AppContent({ loadFeed, showSettings, setShowSettings, showDebug, setSho
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ url: urlText.trim() }),
       })
-      const result = await response.json()
-      if (!response.ok || !result.success) {
-        throw new Error(result.error || `Add article request failed with ${response.status}`)
-      }
+      const result = await readApiResponse(response, 'POST /api/url-to-article')
+      if (!response.ok) throw new Error(`Add article request failed with ${response.status}`)
       if (result.payload) ingestDayPayload(result.payload)
       setAddArticleUrlInput('')
       setIsClipboardPrefill(false)

--- a/docs/client/interaction-and-selection.md
+++ b/docs/client/interaction-and-selection.md
@@ -1,7 +1,7 @@
 ---
 name: client/interaction-and-selection
 description: Client-side interaction architecture, selection modes, and foldable containers.
-last_updated: 2026-05-12 08:22
+last_updated: 2026-05-22 11:20
 ---
 # Client: Interaction and Selection
 
@@ -49,6 +49,13 @@ Selection behavior is implemented as a **declarative state machine** with a smal
 - **PodcastPlayer**
   - A minimal native-audio surface fixed to the bottom 15% of the viewport.
   - Owns playback, 15-second rewind, 10-second forward, and close controls. Closing unmounts the player and revokes the object URL through `App.jsx` cleanup.
+- **App header quick actions (`App.jsx`)**
+  - Adds an **Add Article** control immediately left of the Debug control.
+  - Toggling Add Article reveals an inline URL input panel.
+  - If the user types/pastes a valid URL into the input, the client auto-submits `POST /api/url-to-article`.
+  - On success, the returned day payload is ingested via `ingestDayPayload`, so the new manual article appears without a full reload.
+  - On panel open, the client attempts clipboard prefill (`navigator.clipboard.readText()`): valid URL text is inserted into the input but intentionally **not auto-submitted**.
+  - In clipboard-prefill mode, explicit user confirmation is required via the **Add** button.
 - **RemovedOrderSlot**
   - Wraps newsletter and section containers in flex lists.
   - Subscribes to `useAllArticlesRemoved(date, urls)` once for the grouped URL set and passes the result into the rendered container.


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to add an arbitrary article URL into today’s daily payload from the client header, integrated with the backend `/api/url-to-article` flow.
- Improve UX by detecting a URL in the clipboard and prefilling the add form while avoiding accidental automatic submission when the value came from the clipboard.
- Reuse the server-side normalization approach client-side so inputs are robust to missing scheme, `www`, extra whitespace, and common URL permutations.

### Description
- Added an `Add Article` header button and inline panel to the left of the Debug icon and implemented the input UI and Add button in `client/src/App.jsx`.
- Introduced `canonicalizeCandidateUrl` to normalize/validate URL candidates (trim, accept protocol-less input, strip `www.`, normalize host casing, and accept with/without path) and new state variables `isAddArticleOpen`, `addArticleUrlInput`, `isAddArticleSubmitting`, and `isClipboardPrefill` to model the interaction state.
- Implemented clipboard detection on panel open using `navigator.clipboard.readText()` to prefill the textbox when the clipboard contains a URL while setting a flag so that clipboard-prefill does not auto-submit and instead enables the `Add` button.
- Wired submission to the backend `POST /api/url-to-article` endpoint via `fetch`, and on success integrated the returned daily payload into the client store using `ingestDayPayload`; also updated imports to include the `Link` and `Plus` icons and `ingestDayPayload`.

### Testing
- Ran client dependency installation with `npm install` which completed successfully.
- Built the client with `npm run build` and the build finished successfully (production bundle generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a101d1f5300833299b70944a4340d6b)