### PR TITLE
fix(selection): skip read articles on long-press container select

### DIFF
--- a/client/src/store/articleStore.js
+++ b/client/src/store/articleStore.js
@@ -637,7 +637,8 @@ export function useSelectedArticles() {
 // ─── Interaction ─────────────────────────────────────────────────────────────
 
 function isArticleKeyDisabled(key) {
-  return Boolean(articlesByKey.get(key)?.removed)
+  const slice = articlesByKey.get(key)
+  return Boolean(slice?.removed) || Boolean(slice?.read?.isRead)
 }
 
 function getInteractionSnapshot() {


### PR DESCRIPTION
## Summary
Long-pressing a container (day, newsletter, category) now skips both removed *and* read articles when bulk-selecting. Previously only removed articles were excluded.

**Root cause:** `isArticleKeyDisabled` in `articleStore.js` only checked `removed`; `read.isRead` was ignored.