### PR TITLE
docs: update interaction docs to reflect read articles being skipped on long-press select

### DIFF
--- a/docs/client/interaction-and-selection.md
+++ b/docs/client/interaction-and-selection.md
@@ -1,7 +1,7 @@
 ---
 name: client/interaction-and-selection
 description: Client-side interaction architecture, selection modes, and foldable containers.
-last_updated: 2026-05-12 08:22
+last_updated: 2026-05-29 11:16
 ---
 # Client: Interaction and Selection
 
@@ -23,7 +23,7 @@ Selection behavior is implemented as a **declarative state machine** with a smal
   - Persists `expandedContainerIds` to `localStorage` (`expandedContainers:v1` key). Selection is ephemeral and resets on page reload.
 - `reducers/interactionReducer.js`
   - The single source of truth for transitions.
-  - Accepts an `isDisabled(id)` predicate so removed articles are blocked without maintaining a duplicated disabled-ID set.
+  - Accepts an `isDisabled(id)` predicate so removed and read articles are blocked without maintaining a duplicated disabled-ID set.
   - Suppression latch is time-windowed (800ms): set after every long press, consumed (cleared) on the next short press for the same target within the window.
 - `hooks/useLongPress.js`
   - Pointer-event long press detection for mobile and desktop.
@@ -37,7 +37,7 @@ Selection behavior is implemented as a **declarative state machine** with a smal
   - On click, calls `interactionActions.itemShortPress(articleId)`:
     - In Normal mode: returns "should open" → opens TLDR/Zen overlay.
     - In Select mode: toggles selection (no open).
-  - Removed articles are disabled by the reducer's `isDisabled(id)` predicate, which resolves the article slice and prevents selection.
+  - Removed and read articles are disabled by the reducer's `isDisabled(id)` predicate, which resolves the article slice and prevents selection.
   - Derives `swipeEnabled = canDrag && !isSelectMode` — disables Framer Motion drag when in select mode.
 - **FoldableContainer**
   - On click, calls `interactionActions.containerShortPress(containerId)` to expand/collapse, regardless of selection mode.

--- a/docs/state-machines/interaction-and-gestures.md
+++ b/docs/state-machines/interaction-and-gestures.md
@@ -1,7 +1,7 @@
 ---
 name: state-machines/interaction-and-gestures
 description: State machines for selection interaction, container expansion, and swipe gestures.
-last_updated: 2026-05-06 06:49, 02cad9b
+last_updated: 2026-05-29 11:16
 ---
 # State Machines: Interaction and Gestures
 
@@ -48,7 +48,7 @@ After a long-press, an 800ms window prevents the subsequent touchend's short-pre
 
 `expandedContainerIds` is persisted to `localStorage` under key `expandedContainers:v1` (JSON array). Hydrated on init. Selection is ephemeral.
 
-Removed articles are blocked through an `isDisabled(id)` predicate passed to the reducer. The predicate resolves the article slice and returns true for removed articles, so disabled state is not duplicated.
+Removed and read articles are blocked through an `isDisabled(id)` predicate passed to the reducer. The predicate resolves the article slice and returns true for either condition, so disabled state is not duplicated.
 
 ---
 


### PR DESCRIPTION
## Summary
docs: update interaction docs to reflect read articles being skipped on long-press select