### PR TITLE
Preserve article images in scraped markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .run/
+.pi-session-stats/
 .env
 .env.*
 .env.sh

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-05-29 10:13
+last_updated: 2026-06-03 06:12
 ---
 
 .
@@ -15,9 +15,6 @@ last_updated: 2026-05-29 10:13
 │     ├── update-frontmatter.yml
 │     ├── weekly-branch-pr-cleanup.yml
 │     └── WORKFLOW_DIAGRAM.md
-├── .pi-session-stats
-│  ├── 019e7246-47fa-7025-9e1a-75ebfa37dfc3.data.js
-│  └── 019e7246-47fa-7025-9e1a-75ebfa37dfc3.html
 ├── adapters
 │  ├── __init__.py
 │  ├── aiwithmike_adapter.py

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-06-03 06:12
+last_updated: 2026-06-03 12:07
 ---
 
 .
@@ -149,6 +149,7 @@ last_updated: 2026-06-03 06:12
 ├── newsletter_config.py
 ├── newsletter_scraper.py
 ├── podcast_service.py
+├── PROJECT_STRUCTURE.md
 ├── pyproject.toml
 ├── README.md
 ├── requirements.txt

--- a/scripts/ops/generate_project_tree.py
+++ b/scripts/ops/generate_project_tree.py
@@ -7,44 +7,45 @@ Usage:
     python generate_tree.py [--all] [--git-ignore] [--ignore-glob PATTERNS] [PATH]
 """
 
-import os
 import sys
 import fnmatch
 import argparse
+import subprocess
 from pathlib import Path
-from typing import Set, List, Optional
+from typing import List, Optional, Set
 
 
-def parse_gitignore(gitignore_path: Path) -> List[str]:
+def git_ignored_paths(base_dir: Path) -> Set[str]:
+    """Paths git ignores under base_dir, honoring .gitignore, .git/info/exclude, and global excludes.
+
+    Delegates to git so the full ignore stack is respected (not just the repo-root .gitignore).
+    Directory entries are returned without their trailing slash. Returns an empty set outside a git repo.
     """
-    Parse .gitignore file and return list of patterns.
-
-    >>> patterns = parse_gitignore(Path('.gitignore'))
-    >>> '__pycache__' in patterns or '__pycache__/' in patterns
-    True
-    """
-    if not gitignore_path.exists():
-        return []
-
-    patterns = []
-    with open(gitignore_path) as f:
-        for line in f:
-            line = line.strip()
-            if line and not line.startswith('#'):
-                patterns.append(line)
-    return patterns
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-o", "-i", "--exclude-standard", "--directory", "-z"],
+            cwd=base_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return set()
+    return {entry.rstrip('/') for entry in result.stdout.split('\0') if entry}
 
 
-def should_ignore(path: Path, base_dir: Path, gitignore_patterns: List[str],
+def should_ignore(path: Path, base_dir: Path, git_ignored: Set[str],
                   extra_patterns: List[str], show_hidden: bool) -> bool:
     """
-    Check if a path should be ignored based on gitignore and extra patterns.
+    Check if a path should be ignored based on git's ignore stack and the extra --ignore-glob patterns.
 
-    >>> should_ignore(Path('node_modules/foo'), Path('.'), ['node_modules'], [], True)
+    >>> should_ignore(Path('node_modules'), Path('.'), {'node_modules'}, [], True)
     True
-    >>> should_ignore(Path('.hidden'), Path('.'), [], [], False)
+    >>> should_ignore(Path('experimental'), Path('.'), set(), ['experimental'], True)
     True
-    >>> should_ignore(Path('.hidden'), Path('.'), [], [], True)
+    >>> should_ignore(Path('.hidden'), Path('.'), set(), [], False)
+    True
+    >>> should_ignore(Path('.hidden'), Path('.'), set(), [], True)
     False
     """
     rel_path = path.relative_to(base_dir)
@@ -54,9 +55,10 @@ def should_ignore(path: Path, base_dir: Path, gitignore_patterns: List[str],
     if not show_hidden and name.startswith('.') and name not in {'.', '..'}:
         return True
 
-    all_patterns = gitignore_patterns + extra_patterns
+    if rel_path_str in git_ignored:
+        return True
 
-    for pattern in all_patterns:
+    for pattern in extra_patterns:
         pattern = pattern.strip()
         if not pattern or pattern.startswith('#'):
             continue
@@ -81,9 +83,8 @@ def should_ignore(path: Path, base_dir: Path, gitignore_patterns: List[str],
 
 
 def generate_tree(directory: Path, prefix: str = "", is_last: bool = True,
-                  base_dir: Optional[Path] = None, gitignore_patterns: Optional[List[str]] = None,
-                  extra_patterns: Optional[List[str]] = None, show_hidden: bool = False,
-                  use_git_ignore: bool = False) -> List[str]:
+                  base_dir: Optional[Path] = None, git_ignored: Optional[Set[str]] = None,
+                  extra_patterns: Optional[List[str]] = None, show_hidden: bool = False) -> List[str]:
     """
     Generate tree structure recursively.
 
@@ -91,14 +92,10 @@ def generate_tree(directory: Path, prefix: str = "", is_last: bool = True,
     """
     if base_dir is None:
         base_dir = directory
-    if gitignore_patterns is None:
-        gitignore_patterns = []
+    if git_ignored is None:
+        git_ignored = set()
     if extra_patterns is None:
         extra_patterns = []
-
-    if use_git_ignore and directory == base_dir:
-        gitignore_file = directory / '.gitignore'
-        gitignore_patterns = parse_gitignore(gitignore_file)
 
     lines = []
 
@@ -109,7 +106,7 @@ def generate_tree(directory: Path, prefix: str = "", is_last: bool = True,
 
     entries = [
         e for e in entries
-        if not should_ignore(e, base_dir, gitignore_patterns, extra_patterns, show_hidden)
+        if not should_ignore(e, base_dir, git_ignored, extra_patterns, show_hidden)
     ]
 
     for i, entry in enumerate(entries):
@@ -127,10 +124,9 @@ def generate_tree(directory: Path, prefix: str = "", is_last: bool = True,
                 prefix + extension,
                 is_last_entry,
                 base_dir,
-                gitignore_patterns,
+                git_ignored,
                 extra_patterns,
-                show_hidden,
-                use_git_ignore
+                show_hidden
             )
             lines.extend(sub_lines)
 
@@ -164,16 +160,17 @@ def main():
     if args.ignore_glob:
         extra_patterns = [p.strip() for p in args.ignore_glob.split('|')]
 
+    git_ignored = git_ignored_paths(directory) if args.git_ignore else set()
+
     print(".")
     lines = generate_tree(
         directory,
         "",
         True,
         directory,
-        [],
+        git_ignored,
         extra_patterns,
-        args.all,
-        args.git_ignore
+        args.all
     )
 
     for line in lines:

--- a/summarizer.py
+++ b/summarizer.py
@@ -18,9 +18,34 @@ logger = logging.getLogger("summarizer")
 h = html2text.HTML2Text()
 h.body_width = 0  # Don't wrap lines
 h.unicode_snob = True  # Use unicode instead of ASCII approximations
-h.ignore_images = True  # Skip images, we only need text
+h.ignore_images = False  # Keep images so legit article images reach the LLM
 h.protect_links = True  # Don't wrap URLs
 h.single_line_break = True  # Use single line breaks
+
+
+def _promote_lazy_images(html: str) -> str:
+    """Promote lazy-loaded `data-src` URLs into `src` so real images survive HTML→markdown conversion.
+
+    Many sites set `src` to a placeholder (e.g. a 1px gif) and keep the real URL in `data-src`.
+
+    >>> _promote_lazy_images('<img src="/1px.png" data-src="https://x.com/real.jpg">')
+    '<img src="https://x.com/real.jpg" data-src="https://x.com/real.jpg">'
+    >>> _promote_lazy_images('<img src="https://x.com/real.jpg">')
+    '<img src="https://x.com/real.jpg">'
+    """
+    def _replace(match: re.Match) -> str:
+        tag = match.group(0)
+        data_src = re.search(r'\bdata-src="([^"]+)"', tag)
+        if not data_src:
+            return tag
+        return re.sub(r'\ssrc="[^"]*"', f' src="{data_src.group(1)}"', tag, count=1)
+
+    return re.sub(r"<img\b[^>]*>", _replace, html)
+
+
+def html_to_markdown(html: str) -> str:
+    """Convert HTML to markdown, preserving images (including lazy-loaded ones)."""
+    return h.handle(_promote_lazy_images(html))
 
 _SUMMARY_PROMPT_CACHE = None
 _DIGEST_PROMPT_CACHE = None
@@ -237,7 +262,7 @@ def _fetch_github_readme(url: str) -> str:
         logger.info(
             f"Raw fetch succeeded for {raw_url}",
         )
-        return h.handle(response.text)
+        return html_to_markdown(response.text)
     except requests.HTTPError as e:
         if e.response and e.response.status_code == 404:
             master_url = (
@@ -256,7 +281,7 @@ def _fetch_github_readme(url: str) -> str:
                 logger.info(
                     f"Master branch fetch succeeded for {master_url}",
                 )
-                return h.handle(response.text)
+                return html_to_markdown(response.text)
             except Exception:
                 logger.warning(
                     f"Master branch fetch failed for {master_url}",
@@ -264,7 +289,7 @@ def _fetch_github_readme(url: str) -> str:
                 raise
 
     response = scrape_url(url)
-    content = h.handle(response.text)
+    content = html_to_markdown(response.text)
 
     logger.info(
         f"Direct fetch succeeded for {url}",
@@ -282,7 +307,7 @@ def url_to_markdown(url: str) -> str:
         return _fetch_github_readme(url)
 
     response = scrape_url(url)
-    markdown = h.handle(response.text)
+    markdown = html_to_markdown(response.text)
 
     return markdown
 

--- a/summarizer.py
+++ b/summarizer.py
@@ -8,6 +8,7 @@ from typing import Optional
 import requests
 from curl_cffi import requests as curl_requests
 import html2text
+from bs4 import BeautifulSoup
 
 import util
 import urllib.parse as urlparse
@@ -27,20 +28,21 @@ def _promote_lazy_images(html: str) -> str:
     """Promote lazy-loaded `data-src` URLs into `src` so real images survive HTML→markdown conversion.
 
     Many sites set `src` to a placeholder (e.g. a 1px gif) and keep the real URL in `data-src`.
+    Returns the input untouched when there is nothing to promote, so non-HTML input (e.g. Jina's
+    markdown) is passed through verbatim.
 
     >>> _promote_lazy_images('<img src="/1px.png" data-src="https://x.com/real.jpg">')
-    '<img src="https://x.com/real.jpg" data-src="https://x.com/real.jpg">'
-    >>> _promote_lazy_images('<img src="https://x.com/real.jpg">')
-    '<img src="https://x.com/real.jpg">'
+    '<img data-src="https://x.com/real.jpg" src="https://x.com/real.jpg"/>'
+    >>> _promote_lazy_images('plain markdown ![x](https://x.com/real.jpg)')
+    'plain markdown ![x](https://x.com/real.jpg)'
     """
-    def _replace(match: re.Match) -> str:
-        tag = match.group(0)
-        data_src = re.search(r'\bdata-src="([^"]+)"', tag)
-        if not data_src:
-            return tag
-        return re.sub(r'\ssrc="[^"]*"', f' src="{data_src.group(1)}"', tag, count=1)
-
-    return re.sub(r"<img\b[^>]*>", _replace, html)
+    soup = BeautifulSoup(html, "html.parser")
+    lazy_images = [img for img in soup.find_all("img") if img.get("data-src")]
+    if not lazy_images:
+        return html
+    for img in lazy_images:
+        img["src"] = img["data-src"]
+    return str(soup)
 
 
 def html_to_markdown(html: str) -> str:

--- a/summarizer.py
+++ b/summarizer.py
@@ -37,7 +37,7 @@ def _promote_lazy_images(html: str) -> str:
     'plain markdown ![x](https://x.com/real.jpg)'
     """
     soup = BeautifulSoup(html, "html.parser")
-    lazy_images = [img for img in soup.find_all("img") if img.get("data-src")]
+    lazy_images = soup.find_all("img", attrs={"data-src": True})
     if not lazy_images:
         return html
     for img in lazy_images:

--- a/tldr_service.py
+++ b/tldr_service.py
@@ -306,7 +306,7 @@ def _scrape_url_to_markdown_and_html(url: str) -> tuple[str, str | None]:
     if summarizer._is_github_repo_url(url):
         return summarizer._fetch_github_readme(url), None
     response = summarizer.scrape_url(url)
-    return summarizer.h.handle(response.text), response.text
+    return summarizer.html_to_markdown(response.text), response.text
 
 
 def _extract_h1_from_markdown(markdown: str) -> str | None:


### PR DESCRIPTION
Stop stripping images during HTML→markdown conversion (ignore_images was
True), so legit article images reach the summarizer LLM. Also promote
lazy-loaded data-src URLs into src so real images survive instead of 1px
placeholders. Centralize conversion in summarizer.html_to_markdown.