### PR TITLE
fix(trendshift): parse JSON-LD ItemList after site redesign

### DIFF
--- a/adapters/trendshift_adapter.py
+++ b/adapters/trendshift_adapter.py
@@ -1,5 +1,5 @@
+import json
 import logging
-import re
 from datetime import datetime, timezone
 
 from bs4 import BeautifulSoup
@@ -64,53 +64,34 @@ class TrendshiftAdapter(NewsletterAdapter):
 
 
 def _extract_repositories_from_html(html: str) -> list[dict]:
-    """Extract repository cards from Trendshift SSR HTML.
+    """Extract repositories from Trendshift's schema.org JSON-LD ItemList.
 
-    >>> html = '<div class="rounded-lg border border-gray-300 bg-white"><a href="/repositories/1">owner/repo</a><a href="https://github.com/owner/repo">GitHub</a><div class="text-gray-500 text-xs leading-5">A cool project</div></div>'
+    Trendshift server-renders its live trending ranking as an ItemList of
+    SoftwareSourceCode items inside a <script type="application/ld+json"> tag,
+    independent of client-side hydration.
+
+    >>> html = '<script type="application/ld+json">{"@type":"ItemList","itemListElement":[{"item":{"name":"owner/repo","description":"A cool project","codeRepository":"https://github.com/owner/repo"}}]}</script>'
     >>> repos = _extract_repositories_from_html(html)
     >>> repos[0]['name']
     'owner/repo'
     """
     soup = BeautifulSoup(html, "html.parser")
-    cards = soup.select("div.rounded-lg.border.border-gray-300.bg-white")
+    item_list = json.loads(soup.find("script", type="application/ld+json").string)
+
     repositories = []
     seen_urls = set()
-
-    for card in cards:
-        repo_name = _extract_repo_name(card)
-        if not repo_name:
+    for entry in item_list["itemListElement"]:
+        item = entry["item"]
+        url = item["codeRepository"]
+        if url in seen_urls:
             continue
-
-        full_url = f"https://github.com/{repo_name}"
-        if full_url in seen_urls:
-            continue
-        seen_urls.add(full_url)
-
-        description_element = card.select_one("div.text-gray-500.text-xs.leading-5")
-        description = description_element.get_text(strip=True) if description_element else ""
-
+        seen_urls.add(url)
         repositories.append(
-            {"name": repo_name, "url": full_url, "description": description}
+            {
+                "name": item["name"],
+                "url": url,
+                "description": item.get("description", "").strip(),
+            }
         )
 
     return repositories
-
-
-def _extract_repo_name(card) -> str | None:
-    """Extract 'owner/repo' from a Trendshift card element.
-
-    Tries the internal trendshift link text first (which displays as 'owner/repo'),
-    then falls back to parsing a github.com href.
-    """
-    internal_link = card.select_one('a[href*="/repositories/"]')
-    if internal_link:
-        text = internal_link.get_text(strip=True)
-        if "/" in text:
-            return text
-
-    github_link = card.select_one('a[href*="github.com/"]')
-    if not github_link:
-        return None
-    href = github_link.get("href", "")
-    match = re.search(r"github\.com/([^/?#]+/[^/?#]+)", href)
-    return match.group(1) if match else None

--- a/adapters/trendshift_adapter.py
+++ b/adapters/trendshift_adapter.py
@@ -76,7 +76,8 @@ def _extract_repositories_from_html(html: str) -> list[dict]:
     'owner/repo'
     """
     soup = BeautifulSoup(html, "html.parser")
-    item_list = json.loads(soup.find("script", type="application/ld+json").string)
+    json_ld_blocks = (json.loads(script.string) for script in soup.find_all("script", type="application/ld+json"))
+    item_list = next(block for block in json_ld_blocks if block.get("@type") == "ItemList")
 
     repositories = []
     seen_urls = set()

--- a/tests/unit/test_trendshift_adapter.py
+++ b/tests/unit/test_trendshift_adapter.py
@@ -1,15 +1,23 @@
-from adapters.trendshift_adapter import _extract_repositories_from_html, _extract_repo_name
-from bs4 import BeautifulSoup
+import json
+
+from adapters.trendshift_adapter import _extract_repositories_from_html
 
 
-def test_extract_repositories_from_html_parses_card():
-    html = """
-    <div class="rounded-lg border border-gray-300 bg-white">
-        <a href="/repositories/123">owner/repo</a>
-        <a href="https://github.com/owner/repo">GitHub</a>
-        <div class="text-gray-500 text-xs leading-5">A cool project</div>
-    </div>
-    """
+def _ld_json_html(items: list[dict]) -> str:
+    payload = {"@type": "ItemList", "itemListElement": [{"item": item} for item in items]}
+    return f'<script type="application/ld+json">{json.dumps(payload)}</script>'
+
+
+def test_extract_repositories_from_html_parses_item():
+    html = _ld_json_html(
+        [
+            {
+                "name": "owner/repo",
+                "description": "A cool project",
+                "codeRepository": "https://github.com/owner/repo",
+            }
+        ]
+    )
     repos = _extract_repositories_from_html(html)
     assert len(repos) == 1
     assert repos[0]["name"] == "owner/repo"
@@ -18,33 +26,19 @@ def test_extract_repositories_from_html_parses_card():
 
 
 def test_extract_repositories_deduplicates_by_url():
-    html = """
-    <div class="rounded-lg border border-gray-300 bg-white">
-        <a href="/repositories/1">owner/repo</a>
-        <div class="text-gray-500 text-xs leading-5">First</div>
-    </div>
-    <div class="rounded-lg border border-gray-300 bg-white">
-        <a href="/repositories/2">owner/repo</a>
-        <div class="text-gray-500 text-xs leading-5">Duplicate</div>
-    </div>
-    """
+    html = _ld_json_html(
+        [
+            {"name": "owner/repo", "description": "First", "codeRepository": "https://github.com/owner/repo"},
+            {"name": "owner/repo", "description": "Duplicate", "codeRepository": "https://github.com/owner/repo"},
+        ]
+    )
     repos = _extract_repositories_from_html(html)
     assert len(repos) == 1
 
 
-def test_extract_repo_name_from_internal_link():
-    html = '<div><a href="/repositories/123">acme/widget</a></div>'
-    card = BeautifulSoup(html, "html.parser").div
-    assert _extract_repo_name(card) == "acme/widget"
-
-
-def test_extract_repo_name_from_github_link_fallback():
-    html = '<div><a href="https://github.com/acme/widget">GitHub</a></div>'
-    card = BeautifulSoup(html, "html.parser").div
-    assert _extract_repo_name(card) == "acme/widget"
-
-
-def test_extract_repo_name_returns_none_for_empty_card():
-    html = "<div><span>No links here</span></div>"
-    card = BeautifulSoup(html, "html.parser").div
-    assert _extract_repo_name(card) is None
+def test_extract_repositories_strips_description_whitespace():
+    html = _ld_json_html(
+        [{"name": "owner/repo", "description": "Trailing space. ", "codeRepository": "https://github.com/owner/repo"}]
+    )
+    repos = _extract_repositories_from_html(html)
+    assert repos[0]["description"] == "Trailing space."

--- a/tests/unit/test_trendshift_adapter.py
+++ b/tests/unit/test_trendshift_adapter.py
@@ -36,6 +36,17 @@ def test_extract_repositories_deduplicates_by_url():
     assert len(repos) == 1
 
 
+def test_extract_repositories_selects_item_list_among_other_json_ld():
+    item = {"name": "owner/repo", "description": "A cool project", "codeRepository": "https://github.com/owner/repo"}
+    html = (
+        '<script type="application/ld+json">{"@type": "Organization", "name": "Trendshift"}</script>'
+        + _ld_json_html([item])
+    )
+    repos = _extract_repositories_from_html(html)
+    assert len(repos) == 1
+    assert repos[0]["name"] == "owner/repo"
+
+
 def test_extract_repositories_strips_description_whitespace():
     html = _ld_json_html(
         [{"name": "owner/repo", "description": "Trailing space. ", "codeRepository": "https://github.com/owner/repo"}]


### PR DESCRIPTION
## Root cause

The Trendshift adapter never produced any articles after the first run. Trendshift redesigned trendshift.io into a Next.js app and renamed all its Tailwind classes (e.g. `bg-white border-gray-300` → `bg-card border-border`). The adapter's card selector:

```python
soup.select("div.rounded-lg.border.border-gray-300.bg-white")
```

now matches **zero** elements, so `_extract_repositories_from_html` returned `[]`. Since per-adapter errors are isolated in `scrape_single_source_for_date` and an empty list isn't an error, Trendshift silently produced nothing on every scrape — no crash, no log. It worked once on the old layout, then returned empty forever.

## Fix

Investigated the live page via CDP: the redesigned card DOM hydrates descriptions client-side (useless to the serverless scraper, which has no browser). But Trendshift server-renders a clean **schema.org JSON-LD `ItemList`** in a `<script type="application/ld+json">` tag, carrying `name`, `description`, and `codeRepository` (GitHub URL) for all repos. It's present in the plain HTTP response, so it works in production.

- Rewrote `_extract_repositories_from_html` to parse the JSON-LD `ItemList`.
- Removed the now-obsolete `_extract_repo_name` div-scraping helper.
- Updated unit tests to the JSON-LD structure.

Structured data is far less likely to churn than Tailwind class names. If the JSON-LD ever disappears, the adapter now fails **loudly** (logged with traceback) rather than silently returning empty.

## Verification

Against the real fetched page: 25 articles with titles, GitHub URLs, and descriptions flowing correctly through the full `scrape_date` pipeline (`source_id`, category, type all stamped). Doctest and the 3 updated unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)