### PR TITLE
Add per-source card color palettes, starting with GitHub

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-06-03 12:07
+last_updated: 2026-06-09 04:48
 ---
 
 .
@@ -116,7 +116,8 @@ last_updated: 2026-06-03 12:07
 │  │  │  └── articleStore.test.js
 │  │  ├── App.jsx
 │  │  ├── index.css
-│  │  └── main.jsx
+│  │  ├── main.jsx
+│  │  └── sourceThemes.css
 │  ├── .gitignore
 │  ├── .nvmrc
 │  ├── biome.json

--- a/client/UI_DESIGN.md
+++ b/client/UI_DESIGN.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-04-20 08:32, 3c385a5
+last_updated: 2026-06-09 05:19
 ---
 # UI Design Principles
 
@@ -60,6 +60,10 @@ This means a heading and an unread article title share the same color (they're b
 Brand blue appears sparingly and with purpose: the TLDR. period, the loading spinner, the progress bar in zen mode, focus rings, and the selection checkmark. It marks interactive or state-change moments, not decoration.
 
 The single orphan-color violation that existed (a purple progress bar in zen mode) was replaced with brand blue — every accent color should connect to the palette (`ArticleCard.jsx:119`).
+
+### Some sources bring their own palette
+
+Cards from a handful of recognizable domains swap the default light surface for that source's own colors — the same four roles (primary, tertiary, chrome, plus a background), just resolved to the brand rather than the slate scale. A GitHub card reads as dark the way GitHub does; the favicon keeps a light tile so it stays legible against it. This is an extension of the role system, not an escape from it: each source still maps to the same handful of roles, so the hierarchy holds regardless of palette. When adding a domain, see `components/ArticleCard.jsx` (the `SOURCE_THEMES` hostname→theme map) and `sourceThemes.css` (the per-theme palette block).
 
 ## Spacing is hierarchy made visible
 

--- a/client/src/components/ArticleCard.jsx
+++ b/client/src/components/ArticleCard.jsx
@@ -228,6 +228,7 @@ function ArticleCard({ articleKey }) {
                 hostname={hostname}
                 displayDomain={displayDomain}
                 articleMeta={slice.articleMeta}
+                sourceTheme={sourceTheme}
                 onClose={() => handleSummaryClose()}
                 onMarkRemoved={() => {
                   handleSummaryClose(false)

--- a/client/src/components/ArticleCard.jsx
+++ b/client/src/components/ArticleCard.jsx
@@ -44,32 +44,34 @@ function ArticleTitle({ isRead, title }) {
   )
 }
 
-function ArticleMeta({ hostname, domain, articleMeta }) {
+function ArticleFavicon({ hostname, domain }) {
   const faviconUrl = getFaviconUrl(hostname)
+  if (!faviconUrl) return null
 
   return (
-    <div className="flex items-center gap-2 min-w-0">
-      {faviconUrl && (
-        <div className="w-4 h-4 rounded-full bg-white border border-slate-200 overflow-hidden flex items-center justify-center shrink-0">
-          <img
-            src={faviconUrl}
-            alt={domain}
-            className="w-full h-full object-contain"
-            loading="lazy"
-            decoding="async"
-            onError={(event) => { event.currentTarget.style.visibility = 'hidden' }}
-          />
-        </div>
-      )}
-      <div className="flex items-baseline gap-1.5 text-xs leading-none min-w-0">
-        <span className="article-card-domain font-medium text-slate-400 shrink-0">
-          {domain && domain}
-        </span>
-        <span className="article-card-sep text-slate-300 shrink-0">·</span>
-        <span className="article-card-meta font-normal text-slate-400 truncate">
-          {articleMeta}
-        </span>
-      </div>
+    <div className="article-card-favicon w-10 h-10 self-center rounded-lg bg-white border border-slate-200 overflow-hidden flex items-center justify-center shrink-0">
+      <img
+        src={faviconUrl}
+        alt={domain}
+        className="w-5 h-5 object-contain"
+        loading="lazy"
+        decoding="async"
+        onError={(event) => { event.currentTarget.style.visibility = 'hidden' }}
+      />
+    </div>
+  )
+}
+
+function ArticleMeta({ domain, articleMeta }) {
+  return (
+    <div className="flex items-baseline gap-1.5 text-xs leading-none min-w-0">
+      <span className="article-card-domain font-medium text-slate-400 shrink-0">
+        {domain && domain}
+      </span>
+      <span className="article-card-sep text-slate-300 shrink-0">·</span>
+      <span className="article-card-meta font-normal text-slate-400 truncate">
+        {articleMeta}
+      </span>
     </div>
   )
 }
@@ -198,6 +200,10 @@ function ArticleCard({ articleKey }) {
           `}
         >
           <div className="p-4 flex items-center gap-3">
+            {!isRemoved && (
+              <ArticleFavicon hostname={hostname} domain={displayDomain} />
+            )}
+
             <div className="flex flex-col gap-1.5 min-w-0 flex-1">
               <ArticleTitle
                 isRead={isRead}
@@ -206,7 +212,6 @@ function ArticleCard({ articleKey }) {
 
               {!isRemoved && (
                 <ArticleMeta
-                  hostname={hostname}
                   domain={displayDomain}
                   articleMeta={slice.articleMeta}
                 />

--- a/client/src/components/ArticleCard.jsx
+++ b/client/src/components/ArticleCard.jsx
@@ -199,7 +199,7 @@ function ArticleCard({ articleKey }) {
             ${summary.expanded && !stateLoading ? 'ring-1 ring-brand-200/60 shadow-elevated' : ''}
           `}
         >
-          <div className="p-4 flex items-center gap-3">
+          <div className="p-4 flex items-center gap-4">
             {!isRemoved && (
               <ArticleFavicon hostname={hostname} domain={displayDomain} />
             )}

--- a/client/src/components/ArticleCard.jsx
+++ b/client/src/components/ArticleCard.jsx
@@ -26,10 +26,14 @@ function ErrorToast({ message, onDismiss }) {
   )
 }
 
+// Hostnames whose cards adopt the source's color palette. See sourceThemes.css.
+const SOURCE_THEMES = { 'github.com': 'github' }
+
 function ArticleTitle({ isRead, title }) {
   return (
     <span
       className={`
+        article-card-title
         text-[15px] font-display font-medium leading-snug text-slate-900
         block tracking-tight
         ${isRead ? 'text-slate-400 font-normal' : ''}
@@ -58,11 +62,11 @@ function ArticleMeta({ hostname, domain, articleMeta }) {
         </div>
       )}
       <div className="flex items-baseline gap-1.5 text-xs leading-none min-w-0">
-        <span className="font-medium text-slate-400 shrink-0">
+        <span className="article-card-domain font-medium text-slate-400 shrink-0">
           {domain && domain}
         </span>
-        <span className="text-slate-300 shrink-0">·</span>
-        <span className="font-normal text-slate-400 truncate">
+        <span className="article-card-sep text-slate-300 shrink-0">·</span>
+        <span className="article-card-meta font-normal text-slate-400 truncate">
           {articleMeta}
         </span>
       </div>
@@ -123,6 +127,8 @@ function ArticleCard({ articleKey }) {
     }
   })()
 
+  const sourceTheme = SOURCE_THEMES[hostname]
+
   const handleCardClick = (e) => {
     if (isDragging) return
 
@@ -144,6 +150,7 @@ function ArticleCard({ articleKey }) {
     <Selectable id={componentId} disabled={isRemoved}>
       <motion.div
         layout
+        data-source-theme={sourceTheme}
         className={`relative ${summary.expanded && !stateLoading ? 'mb-4' : 'mb-2.5'}`}
       >
         <div className={`absolute inset-0 rounded-xl bg-slate-100 flex items-center justify-end pr-8 pointer-events-none transition-opacity ${isDragging ? 'opacity-100' : 'opacity-0'}`}>
@@ -179,6 +186,7 @@ function ArticleCard({ articleKey }) {
           data-dragging={isDragging}
           data-can-drag={swipeEnabled}
           className={`
+            article-card-surface
             relative z-10
             rounded-xl border border-slate-200/60
             shadow-card

--- a/client/src/components/BaseOverlay.jsx
+++ b/client/src/components/BaseOverlay.jsx
@@ -27,6 +27,7 @@ function BaseOverlay({
   onMarkRemoved,
   overlayMenu,
   overlayLayers,
+  sourceTheme,
   children,
 }) {
   const containerRef = useRef(null)
@@ -133,7 +134,9 @@ function BaseOverlay({
         <div {...portalRootProps}>
           <div ref={containerRef} className="w-full h-full bg-white flex flex-col animate-zen-enter">
             <div
+              data-source-theme={sourceTheme}
               className={`
+            overlay-header
             relative shrink-0 z-10
             flex items-center justify-between px-4 py-3
             transition-all duration-200
@@ -142,7 +145,7 @@ function BaseOverlay({
             >
               <button
                 onClick={onClose}
-                className="shrink-0 p-2 rounded-full hover:bg-slate-200/80 text-slate-500 hover:text-slate-700 transition-colors"
+                className="overlay-header-icon shrink-0 p-2 rounded-full hover:bg-slate-200/80 text-slate-500 hover:text-slate-700 transition-colors"
               >
                 <ChevronDown size={20} />
               </button>
@@ -151,7 +154,7 @@ function BaseOverlay({
 
               <button
                 onClick={onMarkRemoved}
-                className="shrink-0 p-2 rounded-full hover:bg-green-100 text-slate-500 hover:text-green-600 transition-colors"
+                className="overlay-header-icon shrink-0 p-2 rounded-full hover:bg-green-100 text-slate-500 hover:text-green-600 transition-colors"
               >
                 <Check size={20} />
               </button>

--- a/client/src/components/ZenModeOverlay.jsx
+++ b/client/src/components/ZenModeOverlay.jsx
@@ -6,7 +6,7 @@ import BaseOverlay from './BaseOverlay'
 import ElaborationPreview from './ElaborationPreview'
 import OverlayMarkdown from './OverlayMarkdown'
 
-function ZenModeOverlay({ url, summaryMarkdown, hostname, displayDomain, articleMeta, onClose, onMarkRemoved }) {
+function ZenModeOverlay({ url, summaryMarkdown, hostname, displayDomain, articleMeta, sourceTheme, onClose, onMarkRemoved }) {
   const contextMenu = useOverlayContextMenu(true)
   const faviconUrl = getFaviconUrl(hostname)
   const { elaboration, runElaboration, closeElaboration } = useElaboration({
@@ -38,6 +38,7 @@ function ZenModeOverlay({ url, summaryMarkdown, hostname, displayDomain, article
 
   return (
     <BaseOverlay
+      sourceTheme={sourceTheme}
       headerContent={(
         <a
           href={url}
@@ -48,13 +49,13 @@ function ZenModeOverlay({ url, summaryMarkdown, hostname, displayDomain, article
           {faviconUrl && (
             <img
               src={faviconUrl}
-              className="w-4 h-4 rounded-full border border-slate-200"
+              className="overlay-header-favicon w-4 h-4 rounded-full border border-slate-200"
               alt=""
             />
           )}
-          <span className="text-sm text-slate-500 font-medium">
+          <span className="overlay-header-domain text-sm text-slate-500 font-medium">
             {displayDomain}
-            {truncatedMeta && <span className="text-slate-400"> · {truncatedMeta}</span>}
+            {truncatedMeta && <span className="overlay-header-meta text-slate-400"> · {truncatedMeta}</span>}
           </span>
         </a>
       )}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&display=swap');
+@import "./sourceThemes.css";
 @plugin "@tailwindcss/typography";
 
 @theme {

--- a/client/src/sourceThemes.css
+++ b/client/src/sourceThemes.css
@@ -3,7 +3,13 @@
  * Cards from a source with a custom palette carry [data-source-theme="<source>"]
  * on their root. Each source defines three colors — text, dim, background — plus
  * a matching border. The shared rules below apply them to the card surface, title
- * and meta line, so adding a new source is just a new [data-source-theme] block.
+ * and meta line.
+ *
+ * To add a new source (two steps):
+ *   1. Map its hostname to a theme name in SOURCE_THEMES (ArticleCard.jsx),
+ *      e.g. 'bloomberg.com': 'bloomberg'.
+ *   2. Add a [data-source-theme="bloomberg"] block below with its four colors.
+ * The shared rules are source-agnostic, so step 2 is the only styling needed.
  *
  * Selectors are scoped one level below the themed root (e.g. .article-card-surface)
  * so they outrank Tailwind's single-class utilities without needing !important.

--- a/client/src/sourceThemes.css
+++ b/client/src/sourceThemes.css
@@ -2,8 +2,8 @@
  *
  * Cards from a source with a custom palette carry [data-source-theme="<source>"]
  * on their root. Each source defines three colors — text, dim, background — plus
- * a matching border. The shared rules below apply them to the card surface, title
- * and meta line.
+ * a matching border. The shared rules below apply them to the card surface and to
+ * the reading-overlay sticky header, both of which mirror the same palette.
  *
  * To add a new source (two steps):
  *   1. Map its hostname to a theme name in SOURCE_THEMES (ArticleCard.jsx),
@@ -43,4 +43,32 @@
 [data-source-theme] .article-card-surface:not([data-removed="true"]) .article-card-sep {
   color: var(--card-dim);
   opacity: 0.55;
+}
+
+/* Reading-overlay sticky header — same palette as the card it was opened from.
+ * Here [data-source-theme] sits directly on the header (.overlay-header). */
+[data-source-theme].overlay-header {
+  background: var(--card-bg);
+  border-color: var(--card-border);
+}
+
+[data-source-theme] .overlay-header-domain {
+  color: var(--card-text);
+}
+
+[data-source-theme] .overlay-header-meta {
+  color: var(--card-dim);
+}
+
+[data-source-theme] .overlay-header-favicon {
+  background: #fff;
+}
+
+[data-source-theme] .overlay-header-icon {
+  color: var(--card-dim);
+}
+
+[data-source-theme] .overlay-header-icon:hover {
+  color: var(--card-text);
+  background-color: color-mix(in srgb, var(--card-text) 12%, transparent);
 }

--- a/client/src/sourceThemes.css
+++ b/client/src/sourceThemes.css
@@ -1,0 +1,40 @@
+/* ── Per-source card color palettes ──
+ *
+ * Cards from a source with a custom palette carry [data-source-theme="<source>"]
+ * on their root. Each source defines three colors — text, dim, background — plus
+ * a matching border. The shared rules below apply them to the card surface, title
+ * and meta line, so adding a new source is just a new [data-source-theme] block.
+ *
+ * Selectors are scoped one level below the themed root (e.g. .article-card-surface)
+ * so they outrank Tailwind's single-class utilities without needing !important.
+ * Removed cards keep their standard slate styling via :not([data-removed="true"]). */
+
+[data-source-theme="github"] {
+  --card-bg: #0d1117;
+  --card-text: #e6edf3;
+  --card-dim: #8b949e;
+  --card-border: #30363d;
+}
+
+[data-source-theme] .article-card-surface:not([data-removed="true"]) {
+  background: var(--card-bg);
+  border-color: var(--card-border);
+}
+
+[data-source-theme] .article-card-surface:not([data-removed="true"]) .article-card-title {
+  color: var(--card-text);
+}
+
+[data-source-theme] .article-card-surface[data-read="true"]:not([data-removed="true"]) .article-card-title {
+  color: var(--card-dim);
+}
+
+[data-source-theme] .article-card-surface:not([data-removed="true"]) .article-card-domain,
+[data-source-theme] .article-card-surface:not([data-removed="true"]) .article-card-meta {
+  color: var(--card-dim);
+}
+
+[data-source-theme] .article-card-surface:not([data-removed="true"]) .article-card-sep {
+  color: var(--card-dim);
+  opacity: 0.55;
+}

--- a/docs/client/articles-and-lifecycle.md
+++ b/docs/client/articles-and-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 name: client/articles-and-lifecycle
 description: Client article lifecycle domain and reducer pattern.
-last_updated: 2026-06-09 05:17
+last_updated: 2026-06-09 05:19
 ---
 # Client: Articles and Lifecycle
 
@@ -54,9 +54,3 @@ TIME   ACTOR              ACTION                                TARGET
 ```
 
 `useArticleState` subscribes to a single article slice by date and URL. Batch lifecycle operations build the same reducer patches, then `queueBatchArticlePatches()` groups them by date so a selection action performs one daily payload write per affected date.
-
----
-
-## Per-Domain Card Styling
-
-Cards from select domains adopt that source's color palette (text, dim, background, border) instead of the default light surface. When adding a new domain style, see `components/ArticleCard.jsx` (`SOURCE_THEMES` hostname→theme map) and `sourceThemes.css` (per-theme palette block).

--- a/docs/client/articles-and-lifecycle.md
+++ b/docs/client/articles-and-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 name: client/articles-and-lifecycle
 description: Client article lifecycle domain and reducer pattern.
-last_updated: 2026-05-05 06:38, 36614cc
+last_updated: 2026-06-09 05:17
 ---
 # Client: Articles and Lifecycle
 
@@ -54,3 +54,9 @@ TIME   ACTOR              ACTION                                TARGET
 ```
 
 `useArticleState` subscribes to a single article slice by date and URL. Batch lifecycle operations build the same reducer patches, then `queueBatchArticlePatches()` groups them by date so a selection action performs one daily payload write per affected date.
+
+---
+
+## Per-Domain Card Styling
+
+Cards from select domains adopt that source's color palette (text, dim, background, border) instead of the default light surface. When adding a new domain style, see `components/ArticleCard.jsx` (`SOURCE_THEMES` hostname→theme map) and `sourceThemes.css` (per-theme palette block).


### PR DESCRIPTION
Cards from sources with a custom palette now adopt that source's colors
(text, dim, background). Driven by a data-source-theme attribute on the
card root plus a dedicated sourceThemes.css; GitHub is the first source.