### PR TITLE
Migrate Gemini summarization model to Gemini 3.5 Flash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-05-24 05:46, be365c0
+last_updated: 2026-06-18 20:01
 description: Fundamental instructions for AI coding agents.
 ---
 # Agents Guide
@@ -13,7 +13,7 @@ Newsletter aggregator that scrapes tech newsletters from multiple sources, displ
    * Python: Flask backend, serverless on Vercel
    * React 19 + Vite (frontend) (in `client/`)
    * Supabase PostgreSQL for all data persistence
-   * Gemini 3.1 Pro Preview for summaries
+   * Gemini 3.5 Flash for summaries
 - Storage: Project uses Supabase Database (PostgreSQL) for all data persistence (newsletters, article states, settings, scrape results). Data is stored server-side with client hooks managing async operations.
 - Cache mechanism: Server-side storage with cache-first scraping for past dates (early return if cached). Today always scrapes and unions with cache to capture new articles published later in the day. Daily payloads stored as JSONB in PostgreSQL.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-05-07 12:50, df68ef0
+last_updated: 2026-06-18 20:01
 description: light overview over the project
 ---
 # TLDRScraper
@@ -10,7 +10,7 @@ Mobile Web Newsletter Aggregator that scrapes tech newsletters from multiple sou
 
 - **Frontend**: React 19 + Vite (in `client/`)
 - **Backend**: Flask + Python (serverless on Vercel)
-- **AI**: Google Gemini 3.1 Pro Preview for summaries
+- **AI**: Google Gemini 3.5 Flash for summaries
 
 See the docs in `docs/` for detailed architectural flows & user interactions documentation. Start with `docs/INDEX.md` to navigate correctly. Additionally, read [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md) for a map of the project structure.
 

--- a/summarizer.py
+++ b/summarizer.py
@@ -54,8 +54,8 @@ _DIGEST_PROMPT_CACHE = None
 
 SUMMARIZE_EFFORT_OPTIONS = ("minimal", "low", "medium", "high")
 DEFAULT_THINKING_EFFORT = "medium"
-DEFAULT_MODEL = "gemini-3.1-pro-preview"
-DEFAULT_ELABORATE_MODEL="gemini-3-flash-preview"
+DEFAULT_MODEL = "gemini-3.5-flash"
+DEFAULT_ELABORATE_MODEL="gemini-3.5-flash"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 


### PR DESCRIPTION
Point the app's summarization models (DEFAULT_MODEL and
DEFAULT_ELABORATE_MODEL) at gemini-3.5-flash and update the docs
accordingly. TTS and dev-tooling model references are left untouched.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N6FGovMrjqvXQy6WoXmmZJ