### PR TITLE
Auto-expand next available leaf when a collapsible is exhausted

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-06-09 21:13
+last_updated: 2026-06-20 21:21
 ---
 
 .
@@ -58,6 +58,7 @@ last_updated: 2026-06-09 21:13
 │  │  │  ├── ElaborationPreview.jsx
 │  │  │  ├── Feed.jsx
 │  │  │  ├── FoldableContainer.jsx
+│  │  │  ├── FoldableContainer.test.jsx
 │  │  │  ├── LinkSummarizePreview.jsx
 │  │  │  ├── NewsletterDay.jsx
 │  │  │  ├── OverlayContextMenu.jsx

--- a/client/src/components/FoldableContainer.jsx
+++ b/client/src/components/FoldableContainer.jsx
@@ -1,15 +1,19 @@
 import { ChevronRight } from 'lucide-react'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { interactionActions, useIsExpanded } from '../store/articleStore'
 
 function FoldableContainer({ id, title, children, defaultFolded = false, className = '', headerClassName = '', contentClassName = '', dataAttributes = {} }) {
   const expanded = useIsExpanded(id)
   const isFolded = !expanded
+  const wasAutoFoldedRef = useRef(defaultFolded)
 
   useEffect(() => {
     if (defaultFolded) {
       interactionActions.setExpanded(id, false)
+      // Only on the live exhaustion edge (not the initial already-removed mount).
+      if (!wasAutoFoldedRef.current) interactionActions.expandFirstLeafAfterContainer(id)
     }
+    wasAutoFoldedRef.current = defaultFolded
   }, [defaultFolded, id])
 
   return (

--- a/client/src/components/FoldableContainer.test.jsx
+++ b/client/src/components/FoldableContainer.test.jsx
@@ -1,0 +1,76 @@
+import { render } from '@testing-library/react'
+import { StrictMode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Fresh store + component per test so module-level state and localStorage don't leak.
+let store
+let FoldableContainer
+
+beforeEach(async () => {
+  vi.resetModules()
+  if (typeof localStorage?.clear === 'function') localStorage.clear()
+  store = await import('../store/articleStore.js')
+  FoldableContainer = (await import('./FoldableContainer.jsx')).default
+})
+
+const DATE = '2026-05-04'
+const ALPHA_ID = `section-${DATE}-src1-Alpha`
+const BETA_ID = `section-${DATE}-src1-Beta`
+
+function seedTwoSections() {
+  store.ingestFeedPayloads([{
+    date: DATE,
+    articles: [
+      { url: 's1/1', title: 'A', category: 'src1', sourceId: 'src1', section: 'Alpha', sectionOrder: 0 },
+      { url: 's1/2', title: 'B', category: 'src1', sourceId: 'src1', section: 'Beta', sectionOrder: 1 },
+    ],
+    issues: [{ source_id: 'src1', category: 'src1', subtitle: '' }],
+    digest: null,
+    storage_updated_at: null,
+  }])
+}
+
+function expandedIds() {
+  const raw = localStorage.getItem('expandedContainers:v1')
+  return raw ? JSON.parse(raw) : []
+}
+
+function renderFolded(id, defaultFolded) {
+  return render(
+    <StrictMode>
+      <FoldableContainer id={id} title="t" defaultFolded={defaultFolded}>x</FoldableContainer>
+    </StrictMode>
+  )
+}
+
+describe('FoldableContainer auto-expand on exhaustion', () => {
+  // The user clears a section while reading: the container transitions to folded
+  // mid-session, and the next available section's first card should be exposed.
+  it('exposes the next sections card when a section is exhausted during the session', () => {
+    seedTwoSections()
+    const { rerender } = renderFolded(ALPHA_ID, false)  // Alpha starts populated
+
+    store.applyArticlePatch(`${DATE}::s1/1`, { removed: true })  // exhaust Alpha
+    rerender(
+      <StrictMode>
+        <FoldableContainer id={ALPHA_ID} title="t" defaultFolded={true}>x</FoldableContainer>
+      </StrictMode>
+    )
+
+    expect(expandedIds(), `next section Beta should be exposed, got ${JSON.stringify(expandedIds())}`)
+      .toContain(BETA_ID)
+  })
+
+  // A container that is already exhausted when the feed loads must NOT trigger an
+  // auto-expand — otherwise every reload would force sections open. StrictMode's
+  // double mount makes this the case the ref guard exists to protect.
+  it('does not auto-expand anything when a section is already exhausted at mount', () => {
+    seedTwoSections()
+    store.applyArticlePatch(`${DATE}::s1/1`, { removed: true })  // Alpha exhausted before mount
+
+    renderFolded(ALPHA_ID, true)
+
+    expect(expandedIds(), `already-exhausted mount must not reveal Beta, got ${JSON.stringify(expandedIds())}`)
+      .not.toContain(BETA_ID)
+  })
+})

--- a/client/src/reducers/interactionReducer.js
+++ b/client/src/reducers/interactionReducer.js
@@ -75,9 +75,15 @@ function toggleContainerChildren(state, childIds, isDisabled) {
 
 function toggleExpand(state, containerId) {
   const nextExpanded = cloneSet(state.expandedContainerIds)
-  if (nextExpanded.has(containerId)) nextExpanded.delete(containerId)
-  else nextExpanded.add(containerId)
-  return { ...state, expandedContainerIds: nextExpanded }
+  const nextUserCollapsed = cloneSet(state.userCollapsedContainerIds)
+  if (nextExpanded.has(containerId)) {
+    nextExpanded.delete(containerId)
+    nextUserCollapsed.add(containerId)     // explicit collapse → protect from auto-expand
+  } else {
+    nextExpanded.add(containerId)
+    nextUserCollapsed.delete(containerId)  // explicit (re)open → intent cleared
+  }
+  return { ...state, expandedContainerIds: nextExpanded, userCollapsedContainerIds: nextUserCollapsed }
 }
 
 function setExpanded(state, containerId, expanded) {

--- a/client/src/store/articleStore.js
+++ b/client/src/store/articleStore.js
@@ -549,6 +549,52 @@ function getSnapshotContainerExpanded(containerId) {
   return auxiliary.expandedContainerIds.has(containerId)
 }
 
+// ─── Removal-driven auto-expansion ─────────────────────────────────────────────
+
+// Flat list of every article leaf in visual order across all visible dates, each
+// tagged with the container IDs of its day/source/section ancestors.
+function buildOrderedArticleLeaves() {
+  const leaves = []
+  for (const date of feed.visibleDates) {
+    const dayView = getSnapshotDayView(date)
+    if (!dayView) continue
+    const calendarId = `calendar-${date}`
+    for (const issue of dayView.issues) {
+      const sourceId = issue.source_id
+      const newsletterId = `newsletter-${date}-${sourceId}`
+      const newsletterView = getSnapshotNewsletterView(date, sourceId)
+      if (!newsletterView) continue
+      if (newsletterView.hasSections) {
+        for (const section of newsletterView.sections) {
+          const sectionId = `section-${date}-${sourceId}-${section.key}`
+          for (const key of section.articleKeys) {
+            leaves.push({ removed: Boolean(articlesByKey.get(key)?.removed), ancestorContainerIds: [calendarId, newsletterId, sectionId] })
+          }
+        }
+      } else {
+        for (const key of newsletterView.articleKeys) {
+          leaves.push({ removed: Boolean(articlesByKey.get(key)?.removed), ancestorContainerIds: [calendarId, newsletterId] })
+        }
+      }
+    }
+  }
+  return leaves
+}
+
+// Ancestor container IDs of the first non-removed leaf positioned after the given
+// container's last leaf, or [] when no later available leaf exists. Pure.
+function firstLeafAncestorsAfterContainer(orderedLeaves, containerId) {
+  let lastContainerLeafIndex = -1
+  for (let index = 0; index < orderedLeaves.length; index += 1) {
+    if (orderedLeaves[index].ancestorContainerIds.includes(containerId)) lastContainerLeafIndex = index
+  }
+  if (lastContainerLeafIndex === -1) return []
+  for (let index = lastContainerLeafIndex + 1; index < orderedLeaves.length; index += 1) {
+    if (!orderedLeaves[index].removed) return orderedLeaves[index].ancestorContainerIds
+  }
+  return []
+}
+
 function getSnapshotAnySelected() {
   return auxiliary.selectedCount > 0
 }
@@ -722,6 +768,18 @@ export const interactionActions = Object.freeze({
     const snapshot = getInteractionSnapshot()
     const { state: nextState } = interactionReduce(snapshot, { type: 'SET_EXPANDED', containerId, expanded }, { isDisabled: isArticleKeyDisabled })
     commitInteractionState(nextState)
+  },
+  // After a container auto-collapses on exhaustion, expand the next available
+  // leaf's day/source/section ancestors so its first article card is exposed.
+  expandFirstLeafAfterContainer(containerId) {
+    const targetContainerIds = firstLeafAncestorsAfterContainer(buildOrderedArticleLeaves(), containerId)
+    if (targetContainerIds.length === 0) return
+    const snapshot = getInteractionSnapshot()
+    const nextExpanded = new Set(snapshot.expandedContainerIds)
+    const sizeBefore = nextExpanded.size
+    for (const id of targetContainerIds) nextExpanded.add(id)
+    if (nextExpanded.size === sizeBefore) return
+    commitInteractionState({ ...snapshot, expandedContainerIds: nextExpanded })
   },
 })
 

--- a/client/src/store/articleStore.js
+++ b/client/src/store/articleStore.js
@@ -89,6 +89,7 @@ function loadExpandedFromStorage() {
 
 let auxiliary = {
   expandedContainerIds: loadExpandedFromStorage(),
+  userCollapsedContainerIds: new Set(),  // ephemeral: containers the user explicitly collapsed this session
   suppressNextShortPress: { id: null, untilMs: 0 },
   selectedCount: 0,
 }
@@ -552,9 +553,17 @@ function getSnapshotContainerExpanded(containerId) {
 // ─── Removal-driven auto-expansion ─────────────────────────────────────────────
 
 // Flat list of every article leaf in visual order across all visible dates, each
-// tagged with the container IDs of its day/source/section ancestors.
+// tagged with its day/source/section ancestor container IDs and whether it is
+// available for auto-reveal — removed leaves and leaves inside a user-collapsed
+// container are unavailable.
 function buildOrderedArticleLeaves() {
+  const userCollapsed = auxiliary.userCollapsedContainerIds
   const leaves = []
+  const pushLeaf = (key, ancestorContainerIds) => {
+    const removed = Boolean(articlesByKey.get(key)?.removed)
+    const blocked = ancestorContainerIds.some(id => userCollapsed.has(id))
+    leaves.push({ available: !removed && !blocked, ancestorContainerIds })
+  }
   for (const date of feed.visibleDates) {
     const dayView = getSnapshotDayView(date)
     if (!dayView) continue
@@ -567,21 +576,17 @@ function buildOrderedArticleLeaves() {
       if (newsletterView.hasSections) {
         for (const section of newsletterView.sections) {
           const sectionId = `section-${date}-${sourceId}-${section.key}`
-          for (const key of section.articleKeys) {
-            leaves.push({ removed: Boolean(articlesByKey.get(key)?.removed), ancestorContainerIds: [calendarId, newsletterId, sectionId] })
-          }
+          for (const key of section.articleKeys) pushLeaf(key, [calendarId, newsletterId, sectionId])
         }
       } else {
-        for (const key of newsletterView.articleKeys) {
-          leaves.push({ removed: Boolean(articlesByKey.get(key)?.removed), ancestorContainerIds: [calendarId, newsletterId] })
-        }
+        for (const key of newsletterView.articleKeys) pushLeaf(key, [calendarId, newsletterId])
       }
     }
   }
   return leaves
 }
 
-// Ancestor container IDs of the first non-removed leaf positioned after the given
+// Ancestor container IDs of the first available leaf positioned after the given
 // container's last leaf, or [] when no later available leaf exists. Pure.
 function firstLeafAncestorsAfterContainer(orderedLeaves, containerId) {
   let lastContainerLeafIndex = -1
@@ -590,7 +595,7 @@ function firstLeafAncestorsAfterContainer(orderedLeaves, containerId) {
   }
   if (lastContainerLeafIndex === -1) return []
   for (let index = lastContainerLeafIndex + 1; index < orderedLeaves.length; index += 1) {
-    if (!orderedLeaves[index].removed) return orderedLeaves[index].ancestorContainerIds
+    if (orderedLeaves[index].available) return orderedLeaves[index].ancestorContainerIds
   }
   return []
 }
@@ -695,6 +700,7 @@ function getInteractionSnapshot() {
   return {
     selectedIds,
     expandedContainerIds: auxiliary.expandedContainerIds,
+    userCollapsedContainerIds: auxiliary.userCollapsedContainerIds,
     suppressNextShortPress: auxiliary.suppressNextShortPress,
   }
 }
@@ -718,6 +724,7 @@ function commitInteractionState(nextState) {
 
   auxiliary = {
     expandedContainerIds: nextState.expandedContainerIds,
+    userCollapsedContainerIds: nextState.userCollapsedContainerIds,
     suppressNextShortPress: nextState.suppressNextShortPress,
     selectedCount: newSelectedCount,
   }

--- a/client/src/store/articleStore.test.js
+++ b/client/src/store/articleStore.test.js
@@ -94,6 +94,87 @@ describe('Test 2: fresh scrape adds article to a cached date', () => {
   })
 })
 
+describe('expandFirstLeafAfterContainer: removal-driven auto-expansion', () => {
+  const sectionArticle = (url, sourceId, sectionKey, sectionOrder) =>
+    makeArticle(url, { sourceId, category: sourceId, section: sectionKey, sectionOrder })
+
+  function expandedIds() {
+    const raw = localStorage.getItem('expandedContainers:v1')
+    return raw ? JSON.parse(raw) : []
+  }
+
+  it('expands the next sibling sections ancestors within the same source', () => {
+    const date = '2026-05-04'
+    const alpha = sectionArticle('s1/1', 'src1', 'Alpha', 0)
+    const beta = sectionArticle('s1/2', 'src1', 'Beta', 1)
+    store.ingestFeedPayloads([makePayload(date, [alpha, beta])])
+
+    store.applyArticlePatch(`${date}::${alpha.url}`, { removed: true })  // Alpha exhausted
+    store.interactionActions.expandFirstLeafAfterContainer(`section-${date}-src1-Alpha`)
+
+    expect(expandedIds()).toEqual(expect.arrayContaining([
+      `calendar-${date}`, `newsletter-${date}-src1`, `section-${date}-src1-Beta`,
+    ]))
+    expect(expandedIds()).not.toContain(`section-${date}-src1-Alpha`)
+  })
+
+  it('skips fully-removed sibling sections to reach the first available leaf', () => {
+    const date = '2026-05-04'
+    const alpha = sectionArticle('s1/1', 'src1', 'Alpha', 0)
+    const beta = sectionArticle('s1/2', 'src1', 'Beta', 1)
+    const gamma = sectionArticle('s1/3', 'src1', 'Gamma', 2)
+    store.ingestFeedPayloads([makePayload(date, [alpha, beta, gamma])])
+
+    store.applyArticlePatch(`${date}::${alpha.url}`, { removed: true })
+    store.applyArticlePatch(`${date}::${beta.url}`, { removed: true })
+    store.interactionActions.expandFirstLeafAfterContainer(`section-${date}-src1-Alpha`)
+
+    expect(expandedIds()).toContain(`section-${date}-src1-Gamma`)
+    expect(expandedIds()).not.toContain(`section-${date}-src1-Beta`)
+  })
+
+  it('falls back to the next source within the same day', () => {
+    const date = '2026-05-04'
+    const a = sectionArticle('s1/1', 'src1', 'Alpha', 0)
+    const b = sectionArticle('s2/1', 'src2', 'Alpha', 0)
+    store.ingestFeedPayloads([makePayload(date, [a, b])])
+
+    store.applyArticlePatch(`${date}::${a.url}`, { removed: true })  // whole src1 exhausted
+    store.interactionActions.expandFirstLeafAfterContainer(`newsletter-${date}-src1`)
+
+    expect(expandedIds()).toEqual(expect.arrayContaining([
+      `calendar-${date}`, `newsletter-${date}-src2`, `section-${date}-src2-Alpha`,
+    ]))
+  })
+
+  it('falls back to the next days first leaf', () => {
+    const a = sectionArticle('s1/1', 'src1', 'Alpha', 0)
+    const b = sectionArticle('s1/1', 'src1', 'Alpha', 0)
+    store.ingestFeedPayloads([
+      makePayload('2026-05-04', [a]),
+      makePayload('2026-05-05', [b]),
+    ])
+
+    store.applyArticlePatch(`2026-05-04::${a.url}`, { removed: true })  // whole day exhausted
+    store.interactionActions.expandFirstLeafAfterContainer('calendar-2026-05-04')
+
+    expect(expandedIds()).toEqual(expect.arrayContaining([
+      'calendar-2026-05-05', 'newsletter-2026-05-05-src1', 'section-2026-05-05-src1-Alpha',
+    ]))
+  })
+
+  it('does nothing when there is no later available leaf', () => {
+    const date = '2026-05-04'
+    const a = sectionArticle('s1/1', 'src1', 'Alpha', 0)
+    store.ingestFeedPayloads([makePayload(date, [a])])
+
+    store.applyArticlePatch(`${date}::${a.url}`, { removed: true })
+    store.interactionActions.expandFirstLeafAfterContainer(`section-${date}-src1-Alpha`)
+
+    expect(localStorage.getItem('expandedContainers:v1')).toBeNull()
+  })
+})
+
 describe('Test 3: stale article on refresh prunes selection', () => {
   it('refresh that drops a selected article removes it and clears select-mode if it was the only selection', () => {
     const date = '2026-05-04'

--- a/client/src/store/articleStore.test.js
+++ b/client/src/store/articleStore.test.js
@@ -173,6 +173,46 @@ describe('expandFirstLeafAfterContainer: removal-driven auto-expansion', () => {
 
     expect(localStorage.getItem('expandedContainers:v1')).toBeNull()
   })
+
+  // Manually collapsing a container twice via short press leaves it folded AND
+  // flagged as user-collapsed (the second press collapses an expanded container).
+  function manuallyCollapse(containerId) {
+    store.interactionActions.containerShortPress(containerId)  // fold -> expand
+    store.interactionActions.containerShortPress(containerId)  // expand -> fold (explicit)
+  }
+
+  it('does not re-open a container the user explicitly collapsed; skips to the next available leaf', () => {
+    const date = '2026-05-04'
+    const alpha = sectionArticle('s1/1', 'src1', 'Alpha', 0)
+    const beta = sectionArticle('s1/2', 'src1', 'Beta', 1)
+    const gamma = sectionArticle('s2/1', 'src2', 'Gamma', 0)
+    store.ingestFeedPayloads([makePayload(date, [alpha, beta, gamma])])
+
+    manuallyCollapse(`section-${date}-src1-Beta`)            // user closes Beta deliberately
+    store.applyArticlePatch(`${date}::${alpha.url}`, { removed: true })  // Alpha exhausted
+    store.interactionActions.expandFirstLeafAfterContainer(`section-${date}-src1-Alpha`)
+
+    const expanded = JSON.parse(localStorage.getItem('expandedContainers:v1') ?? '[]')
+    expect(expanded, `user-collapsed Beta must stay folded, got ${JSON.stringify(expanded)}`)
+      .not.toContain(`section-${date}-src1-Beta`)
+    expect(expanded, `should skip past Beta to Gamma, got ${JSON.stringify(expanded)}`)
+      .toContain(`section-${date}-src2-Gamma`)
+  })
+
+  it('exposes nothing when the only later leaf is inside a user-collapsed container', () => {
+    const date = '2026-05-04'
+    const alpha = sectionArticle('s1/1', 'src1', 'Alpha', 0)
+    const beta = sectionArticle('s1/2', 'src1', 'Beta', 1)
+    store.ingestFeedPayloads([makePayload(date, [alpha, beta])])
+
+    manuallyCollapse(`section-${date}-src1-Beta`)
+    store.applyArticlePatch(`${date}::${alpha.url}`, { removed: true })
+    store.interactionActions.expandFirstLeafAfterContainer(`section-${date}-src1-Alpha`)
+
+    const expanded = JSON.parse(localStorage.getItem('expandedContainers:v1') ?? '[]')
+    expect(expanded, `no container should be auto-expanded, got ${JSON.stringify(expanded)}`)
+      .not.toContain(`section-${date}-src1-Beta`)
+  })
 })
 
 describe('Test 3: stale article on refresh prunes selection', () => {


### PR DESCRIPTION
When a day/source/category collapses because all its articles were
removed, expand the next available leaf's ancestor chain so its first
article card is exposed. The "next" lookup is the smallest step in
visual order: next sibling category in the same source, else next
source's first leaf in the same day, else the next day's first leaf,
skipping any fully-removed subtrees.

FoldableContainer fires expandFirstLeafAfterContainer on the live
exhaustion edge (not on already-removed mounts). The store walks the
global ordered-leaf list and expands the target's day/source/section
container IDs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SYpjKdAfZqANZZsLpoREik