### PR TITLE
Add Grandimam blog as a newsletter source

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-06-20 21:21
+last_updated: 2026-06-26 15:26
 ---
 
 .
@@ -24,6 +24,7 @@ last_updated: 2026-06-20 21:21
 │  ├── danluu_adapter.py
 │  ├── deepmind_adapter.py
 │  ├── google_research_adapter.py
+│  ├── grandimam_adapter.py
 │  ├── hackernews_adapter.py
 │  ├── hillel_wayne_adapter.py
 │  ├── jessitron_adapter.py

--- a/adapters/grandimam_adapter.py
+++ b/adapters/grandimam_adapter.py
@@ -1,0 +1,114 @@
+"""
+Grandimam (blog.grandimam.com) blog adapter using RSS feed.
+"""
+
+import logging
+from datetime import datetime
+
+import feedparser
+
+from adapters.newsletter_adapter import NewsletterAdapter
+import util
+
+
+logger = logging.getLogger("grandimam_adapter")
+
+
+class GrandimamAdapter(NewsletterAdapter):
+    """Adapter for the Grandimam blog using RSS feed."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.feed_url = "https://blog.grandimam.com/feed.xml"
+
+    @util.retry()
+    def _fetch_feed(self):
+        """Fetch RSS feed content."""
+        response = util.fetch(self.feed_url, timeout=10)
+        response.raise_for_status()
+        return response.content
+
+    def scrape_date(self, date: str, excluded_urls: list[str]) -> dict:
+        """Fetch blog posts for a specific date from RSS feed.
+
+        Args:
+            date: Date string in YYYY-MM-DD format
+            excluded_urls: List of canonical URLs to exclude from results
+
+        Returns:
+            Normalized response dictionary
+        """
+        articles = []
+        excluded_set = set(excluded_urls)
+
+        target_date = datetime.fromisoformat(util.format_date_for_url(date))
+        target_date_str = target_date.strftime("%Y-%m-%d")
+
+        logger.info(f"Fetching articles for {target_date_str} (excluding {len(excluded_urls)} URLs)")
+
+        try:
+            feed_content = self._fetch_feed()
+            feed = feedparser.parse(feed_content)
+
+            logger.info(f"Fetched {len(feed.entries)} total entries from feed")
+
+            for entry in feed.entries:
+                if not entry.get('published_parsed'):
+                    continue
+
+                entry_date = datetime(*entry.published_parsed[:6])
+                entry_date_str = entry_date.strftime("%Y-%m-%d")
+
+                if entry_date_str != target_date_str:
+                    continue
+
+                link = entry.get('link', '')
+                if not link:
+                    continue
+
+                canonical_url = util.canonicalize_url(link)
+
+                if canonical_url in excluded_set:
+                    continue
+
+                article = self._entry_to_article(entry, target_date_str)
+                if article:
+                    articles.append(article)
+
+            logger.info(f"Found {len(articles)} articles for {target_date_str}")
+
+        except Exception as e:
+            logger.error(f"Error fetching feed: {e}", exc_info=True)
+        return self._normalize_response(articles)
+
+    def _entry_to_article(self, entry: dict, date: str) -> dict | None:
+        """Convert RSS feed entry to article dict.
+
+        Args:
+            entry: feedparser entry dictionary
+            date: Date string
+
+        Returns:
+            Article dictionary or None if entry should be skipped
+        """
+        title = entry.get('title', '')
+        if not title:
+            return None
+
+        link = entry.get('link', '')
+        if not link:
+            return None
+
+        summary = entry.get('summary', '')
+        if summary and len(summary) > 300:
+            summary = summary[:300] + '...'
+
+        return {
+            "title": title,
+            "article_meta": summary if summary else "",
+            "url": link,
+            "category": self.config.category_display_names.get('blog', "Grandimam"),
+            "date": date,
+            "newsletter_type": "blog",
+            "removed": False,
+        }

--- a/newsletter_config.py
+++ b/newsletter_config.py
@@ -283,6 +283,17 @@ NEWSLETTER_CONFIGS = {
         category_display_names={"blog": "Armin Ronacher"},
         sort_order=7,  # High priority - Flask/Ruff creator
     ),
+    "grandimam": NewsletterSourceConfig(
+        source_id="grandimam",
+        display_name="Grandimam",
+        base_url="https://blog.grandimam.com",
+        url_pattern="",
+        types=["blog"],
+        user_agent="Mozilla/5.0 (compatible; Newsletter-Aggregator/1.0)",
+        article_pattern="",
+        category_display_names={"blog": "Grandimam"},
+        sort_order=7,  # ~1/week - bursty Python/performance blog
+    ),
     "trendshift": NewsletterSourceConfig(
         source_id="trendshift",
         display_name="Trendshift",

--- a/newsletter_scraper.py
+++ b/newsletter_scraper.py
@@ -86,6 +86,9 @@ def _get_adapter_for_source(config):
     elif config.source_id == "lucumr":
         from adapters.lucumr_adapter import LucumrAdapter
         return LucumrAdapter(config)
+    elif config.source_id == "grandimam":
+        from adapters.grandimam_adapter import GrandimamAdapter
+        return GrandimamAdapter(config)
     elif config.source_id == "trendshift":
         from adapters.trendshift_adapter import TrendshiftAdapter
         return TrendshiftAdapter(config)


### PR DESCRIPTION
## Summary

Adds [blog.grandimam.com](https://blog.grandimam.com/) (Python | Performance & Concurrency) as a new newsletter source.

The site exposes a clean RSS 2.0 feed at `/feed.xml` (`pubDate` + absolute `link` per item), so it fits the existing RSS-adapter pattern (`savannah`, `lucumr`) exactly.

## Changes

- **`adapters/grandimam_adapter.py`** — new `GrandimamAdapter` modeled on the existing feed adapters: fetch `/feed.xml`, filter entries by target date, exclude already-seen URLs, normalize to articles.
- **`newsletter_config.py`** — registered the `grandimam` config (`base_url`, `blog` type, display name, `sort_order=7`).
- **`newsletter_scraper.py`** — added the factory branch mapping `source_id == "grandimam"` to the adapter.

No client changes are needed — the frontend requests a date range and the server scrapes every configured source. `grandimam` is now in `get_default_source_ids()` (25 sources total) and `tldr_service` picks it up automatically.

## Verification

- Confirmed the feed parses with `feedparser` (entries with dates/links/summaries present).
- Exercised the real factory (`_get_adapter_for_source` → `GrandimamAdapter`) and ran `scrape_date` end-to-end against the live feed content across multiple dates: correct date filtering, exclusion handling, and normalization (`source_id` / `category` / `newsletter_type`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fj3NN3WXLGaEt1Vm9vaqmR)_